### PR TITLE
Add the forklift robot model to the simulator

### DIFF
--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: venv
-          key: deps-library-${{ hashfiles('libraries.txt') }}-v2
+          key: deps-library-${{ hashfiles('libraries.txt') }}-v3
       - name: Install Libraries
         run: |
           python3 -m venv venv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       id: cache-dep
       with:
         path: venv
-        key: deps-py${{ matrix.python-version }}-${{ matrix.test-os }}-${{ hashfiles('all-requirements.txt') }}-v2
+        key: deps-py${{ matrix.python-version }}-${{ matrix.test-os }}-${{ hashfiles('all-requirements.txt') }}-v3
     - name: Install Dependencies - Posix
       if: matrix.test-os != 'windows-latest'
       run: |

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -16,8 +16,8 @@ def init_motor_array(webot: Robot) -> 'List[Motor]':
             Wheel(webot, 'right wheel'),
         ),
         Motor(  # TODO: this is a bodge to enable grabber testing
-            LinearMotor(webot, 'left gripper'),
-            LinearMotor(webot, 'right gripper'),
+            Gripper(webot, ('left gripper', 'right gripper')),
+            None,
         ),
     ]
 

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -42,10 +42,11 @@ class Motor:
 
     def __init__(
         self,
-        m0: Union[Wheel, LinearMotor, Gripper],
+        m0: Union[Wheel, LinearMotor, Gripper, None],
         m1: Union[Wheel, LinearMotor, Gripper, None],
     ) -> None:
-        self.m0 = MotorChannel(0, m0)
+        if m0 is not None:
+            self.m0 = MotorChannel(0, m0)
         if m1 is not None:
             self.m1 = MotorChannel(1, m1)
 

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -40,7 +40,11 @@ def translate(sr_speed_val: int, sr_motor: Union[Gripper, Wheel, LinearMotor]) -
 class Motor:
     """Represents a motor board."""
 
-    def __init__(self, m0: Union[Wheel, LinearMotor, Gripper], m1: Union[Wheel, LinearMotor, Gripper, None]) -> None:
+    def __init__(
+        self,
+        m0: Union[Wheel, LinearMotor, Gripper],
+        m1: Union[Wheel, LinearMotor, Gripper, None],
+    ) -> None:
         self.m0 = MotorChannel(0, m0)
         if m1 is not None:
             self.m1 = MotorChannel(1, m1)

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -40,9 +40,10 @@ def translate(sr_speed_val: int, sr_motor: Union[Gripper, Wheel, LinearMotor]) -
 class Motor:
     """Represents a motor board."""
 
-    def __init__(self, m0: Union[Wheel, LinearMotor], m1: Union[Wheel, Gripper]) -> None:
+    def __init__(self, m0: Union[Wheel, LinearMotor, Gripper], m1: Union[Wheel, LinearMotor, Gripper, None]) -> None:
         self.m0 = MotorChannel(0, m0)
-        self.m1 = MotorChannel(1, m1)
+        if m1 is not None:
+            self.m1 = MotorChannel(1, m1)
 
 
 class MotorChannel:

--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -15,6 +15,10 @@ def init_motor_array(webot: Robot) -> 'List[Motor]':
             Wheel(webot, 'left wheel'),
             Wheel(webot, 'right wheel'),
         ),
+        Motor(  # TODO: this is a bodge to enable grabber testing
+            LinearMotor(webot, 'left gripper'),
+            LinearMotor(webot, 'right gripper'),
+        ),
     ]
 
 

--- a/modules/sr/robot/motor_devices.py
+++ b/modules/sr/robot/motor_devices.py
@@ -53,8 +53,7 @@ class Gripper(MotorBase):
     Our default robot's gripper has its fingers attached to linear motors.
     This class allows you to control these as a single entity to open/close.
 
-    You should initialise with the motor_name as the two Webots motor names separated by
-    a pipe character (|)
+    You should initialise with the motor_name as a tuple of the two Webots motor names
     """
 
     def __init__(self, webot: Robot, motor_names: Tuple[str, str]) -> None:

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -132,8 +132,7 @@ class Robot:
         self._init_motors()
 
         # Ruggeduinos
-        # TODO: removing this is a bodge to enable forklift testing
-        # self._init_ruggeduinos()
+        self._init_ruggeduinos()
 
         # No camera for SR2021
 

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -132,7 +132,8 @@ class Robot:
         self._init_motors()
 
         # Ruggeduinos
-        self._init_ruggeduinos()
+        # TODO: removing this is a bodge to enable forklift testing
+        # self._init_ruggeduinos()
 
         # No camera for SR2021
 

--- a/modules/sr/robot/ruggeduino.py
+++ b/modules/sr/robot/ruggeduino.py
@@ -14,20 +14,20 @@ def init_ruggeduino_array(webot: Robot) -> 'List[Ruggeduino]':
         "Front Right DS",
         "Left DS",
         "Right DS",
-        "Back Left DS",
-        "Back Right DS",
+        "Front DS",
+        "Back DS",
     ]
     switch_names = [
-        "front bump sensor",
+        # "front bump sensor",
         "back bump sensor",
     ]
-    led_names = [
-        "led 1",
-        "led 2",
-        "led 3",
-        "led 4",
-        "led 5",
-        "led 6",
+    led_names: List[str] = [
+        # "led 1",
+        # "led 2",
+        # "led 3",
+        # "led 4",
+        # "led 5",
+        # "led 6",
     ]
 
     analogue_input_array = [DistanceSensor(webot, name) for name in dist_sensor_names]

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -19,10 +19,10 @@ PROTO SBForklift [
         translation 0 0.05 -0.07
         children [
           DEF LEFT_WHEEL_CLUSTER Transform {
-            translation -0.101 0 0
+            translation 0.101 0 0
             children [
               DEF LEFT_WHEEL_MOUNT Solid {
-                translation 0.04 0 0
+                translation -0.04 0 0
                 rotation 0 0 1 1.5708
                 name "left wheel mount"
                 children [
@@ -45,7 +45,7 @@ PROTO SBForklift [
               DEF LEFT_WHEEL HingeJoint {
                 jointParameters HingeJointParameters {
                   position 0
-                  axis -1 0 0
+                  axis 1 0 0
                 }
                 device [
                   RotationalMotor {
@@ -83,10 +83,10 @@ PROTO SBForklift [
             ]
           }
           DEF RIGHT_WHEEL_CLUSTER Transform {
-            translation 0.101 0 0
+            translation -0.101 0 0
             children [
               DEF RIGHT_WHEEL_MOUNT Solid {
-                translation -0.04 0 0
+                translation 0.04 0 0
                 rotation 0 0 1 1.5708
                 name "right wheel mount"
                 children [
@@ -99,7 +99,7 @@ PROTO SBForklift [
               DEF RIGHT_WHEEL HingeJoint {
                 jointParameters HingeJointParameters {
                   position 0
-                  axis -1 0 0
+                  axis 1 0 0
                 }
                 device [
                   RotationalMotor {

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -422,49 +422,49 @@ PROTO SBForklift [
           }
         ]
       }
-      # DEF flag_pole Solid {
-      #   translation 0 0.25 0
-      #   children [
-      #     LED {
-      #       translation 0 0.1 -0.085
-      #       children [
-      #         Shape {
-      #           appearance PBRAppearance {
-      #             metalness 0
-      #             occlusionMapStrength 130
-      #             emissiveIntensity 10
-      #             baseColor IS flagColour
-      #           }
-      #           geometry Box {
-      #             size 0.005 0.1 0.15
-      #           }
-      #         }
-      #       ]
-      #       name "flag"
-      #       color [
-      #         0.1 0.1 0.7
-      #         1 0.5 0.9
-      #         0.8 0.8 0.1
-      #         0.1 0.7 0.1
-      #       ]
-      #     }
-      #     Shape {
-      #       appearance PBRAppearance {
-      #         baseColor 0.0705882 0.0705882 0.0705882
-      #         roughness 0.4
-      #         metalness 0
-      #       }
-      #       geometry DEF flag_pole Cylinder {
-      #         height 0.3
-      #         radius 0.01
-      #       }
-      #     }
-      #   ]
-      #   boundingObject USE flag_pole
-      #   name "flag pole"
-      #   physics Physics {
-      #   }
-      # }
+      DEF flag_pole Solid {
+        translation 0 0.125 0
+        children [
+          LED {
+            translation 0 0.062 -0.06
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  metalness 0
+                  occlusionMapStrength 130
+                  emissiveIntensity 10
+                  baseColor IS flagColour
+                }
+                geometry Box {
+                  size 0.005 0.075 0.1
+                }
+              }
+            ]
+            name "flag"
+            color [
+              0.1 0.1 0.7
+              1 0.5 0.9
+              0.8 0.8 0.1
+              0.1 0.7 0.1
+            ]
+          }
+          Shape {
+            appearance PBRAppearance {
+              baseColor 0.0705882 0.0705882 0.0705882
+              roughness 0.4
+              metalness 0
+            }
+            geometry DEF flag_pole Cylinder {
+              height 0.2
+              radius 0.01
+            }
+          }
+        ]
+        boundingObject USE flag_pole
+        name "flag pole"
+        physics Physics {
+        }
+      }
       DEF SENSORS Transform {
         translation 0 0 0
         children [

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -495,6 +495,147 @@ PROTO SBForklift [
             name "robot compass"
             rotation 0 1 0 0
           }
+          DEF DISTANCE_SENSORS Group {
+            children [
+              DEF left DistanceSensor {
+                translation 0.152 0.058 0
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 0
+                children [
+                  DEF GEO_DS Transform {
+                    rotation 1 -1 1 -2.0944
+                    children [
+                      Shape {
+                        appearance PBRAppearance {
+                          baseColor 0.1 0.1 1
+                          metalness 0
+                        }
+                        geometry Box {
+                          size 0.045 0.02 0.002
+                        }
+                      }
+                      Transform {
+                        translation -0.013 0 0.007
+                        rotation 1 0 0 1.5708
+                        children [
+                          DEF SONAR_TX Shape {
+                            appearance PBRAppearance {
+                              baseColor 0.92 0.92 0.92
+                              roughness 0.3
+                            }
+                            geometry Cylinder {
+                              radius 0.008
+                              height 0.012
+                            }
+                          }
+                        ]
+                      }
+                      Transform {
+                        translation 0.013 0 0.007
+                        rotation 1 0 0 1.5708
+                        children [
+                          USE SONAR_TX
+                        ]
+                      }
+                    ]
+                  }
+                ]
+                name "Left DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+              DEF right DistanceSensor {
+                translation -0.152 0.058 0
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 3.1416
+                children [
+                  USE GEO_DS
+                ]
+                name "Right DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+              DEF front_left DistanceSensor {
+                translation 0.152 0.07 0.122
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 -1.5708
+                children [
+                  USE GEO_DS
+                ]
+                name "Front Left DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+              DEF front_right DistanceSensor {
+                translation -0.152 0.07 0.122
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 -1.5708
+                children [
+                  USE GEO_DS
+                ]
+                name "Front Right DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+
+              DEF front DistanceSensor {
+                translation 0 0.055 0.011
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 -1.5708
+                children [
+                  Transform {
+                    rotation 1 0 0 -1.5708
+                    children [
+                      USE GEO_DS
+                    ]
+                  }
+                ]
+                name "Front DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+              DEF rear DistanceSensor {
+                translation 0 0.046 -0.14
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 1.5708
+                children [
+                  Transform {
+                    rotation 1 0 0 -1.5708
+                    children [
+                      USE GEO_DS
+                    ]
+                  }
+                ]
+                name "Back DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+            ]
+          }
           TouchSensor {
             translation 0 0.03 -0.15
             rotation 0 1 0 3.14

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -495,6 +495,25 @@ PROTO SBForklift [
             name "robot compass"
             rotation 0 1 0 0
           }
+          TouchSensor {
+            translation 0 0.03 -0.15
+            rotation 0 1 0 3.14
+            children [
+              Shape {
+                appearance PBRAppearance {
+                  baseColor 0.5 0 0
+                  roughness 0.7
+                }
+                geometry DEF BUMPER Box {
+                  size 0.2 0.01 0.01
+                }
+              }
+            ]
+            name "back bump sensor"
+            boundingObject Box {
+              size 0.2 0.01 0.03
+            }
+          }
         ]
       }
     ]

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -134,67 +134,71 @@ PROTO SBForklift [
             translation 0 0.030 0
             name "base"
             children [
-              DEF body_core Transform {
-                translation 0 0 -0.085
+              DEF body_geo Group {
                 children [
-                  Shape {
-                    appearance DEF BODY_COLOUR PBRAppearance {
-                      baseColor IS flagColour
-                      roughness 0.3
-                      metalness 0
-                    }
-                    geometry Box {
-                      size 0.17 0.012 0.11
-                    }
+                  DEF body_core Transform {
+                    translation 0 0 -0.085
+                    children [
+                      Shape {
+                        appearance DEF BODY_COLOUR PBRAppearance {
+                          baseColor IS flagColour
+                          roughness 0.3
+                          metalness 0
+                        }
+                        geometry Box {
+                          size 0.17 0.012 0.11
+                        }
+                      }
+                    ]
                   }
-                ]
-              }
-              DEF body_front_spar Transform {
-                translation 0 0 -0.015
-                children [
-                  Shape {
-                    appearance USE BODY_COLOUR
-                    geometry Box {
-                      size 0.33 0.012 0.03
-                    }
+                  DEF body_front_spar Transform {
+                    translation 0 0 -0.015
+                    children [
+                      Shape {
+                        appearance USE BODY_COLOUR
+                        geometry Box {
+                          size 0.33 0.012 0.03
+                        }
+                      }
+                    ]
                   }
-                ]
-              }
-              DEF body_rear_spar Transform {
-                translation 0 0 -0.15
-                children [
-                  Shape {
-                    appearance USE BODY_COLOUR
-                    geometry Box {
-                      size 0.23 0.012 0.02
-                    }
+                  DEF body_rear_spar Transform {
+                    translation 0 0 -0.15
+                    children [
+                      Shape {
+                        appearance USE BODY_COLOUR
+                        geometry Box {
+                          size 0.23 0.012 0.02
+                        }
+                      }
+                    ]
                   }
-                ]
-              }
-              DEF body_left_arm Transform {
-                translation 0.1525 0.006 0.06
-                children [
-                  Shape {
-                    appearance USE BODY_COLOUR
-                    geometry Box {
-                      size 0.025 0.024 0.12
-                    }
+                  DEF body_left_arm Transform {
+                    translation 0.1525 0.006 0.06
+                    children [
+                      Shape {
+                        appearance USE BODY_COLOUR
+                        geometry Box {
+                          size 0.025 0.024 0.12
+                        }
+                      }
+                    ]
                   }
-                ]
-              }
-              DEF body_right_arm Transform {
-                translation -0.1525 0.006 0.06
-                children [
-                  Shape {
-                    appearance USE BODY_COLOUR
-                    geometry Box {
-                      size 0.025 0.024 0.12
-                    }
+                  DEF body_right_arm Transform {
+                    translation -0.1525 0.006 0.06
+                    children [
+                      Shape {
+                        appearance USE BODY_COLOUR
+                        geometry Box {
+                          size 0.025 0.024 0.12
+                        }
+                      }
+                    ]
                   }
                 ]
               }
             ]
-            boundingObject USE body_core
+            boundingObject USE body_geo
             physics Physics {
             }
           }
@@ -492,13 +496,9 @@ PROTO SBForklift [
     name IS model
     model IS model
     boundingObject Transform {
-      translation 0 0.030 -0.065
+      translation 0 0.030 0.015
       children [
-        Shape {
-          geometry Box {
-            size 0.17 0.012 0.16
-          }
-        }
+        USE body_geo
       ]
     }
     physics Physics {

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -283,7 +283,8 @@ PROTO SBForklift [
             rotation 0 0 1 1.5708
             children [
               DEF SUPPORT_ROD Shape {
-                appearance PBRAppearance {}
+                appearance PBRAppearance {
+                }
                 geometry Cylinder {
                   radius 0.004
                   height 0.3
@@ -292,7 +293,8 @@ PROTO SBForklift [
             ]
             name "Support rod 1"
             boundingObject USE SUPPORT_ROD
-            physics Physics {}
+            physics Physics {
+            }
           }
           Solid {
             translation 0 0 0.08
@@ -302,7 +304,8 @@ PROTO SBForklift [
             ]
             name "Support rod 2"
             boundingObject USE SUPPORT_ROD
-            physics Physics {}
+            physics Physics {
+            }
           }
           DEF GRABBER_LEFT Transform {
             translation 0.13 0 0.055
@@ -327,7 +330,8 @@ PROTO SBForklift [
                       translation 0 0 0.067
                       children [
                         Shape {
-                          appearance PBRAppearance {}
+                          appearance PBRAppearance {
+                          }
                           geometry Box {
                             size 0.012 0.05 0.2
                           }

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -26,13 +26,13 @@ PROTO SBForklift [
                 rotation 0 0 1 1.5708
                 name "left wheel mount"
                 children [
-                  Shape {
+                  DEF MOTOR_HOUSING Shape {
                     appearance PBRAppearance {
                       baseColor 0 0.0051864 0
                       roughness 0.3
                       metalness 0
                     }
-                    geometry DEF MOTOR_HOUSING Cylinder {
+                    geometry Cylinder {
                       height 0.07
                       radius 0.015
                     }
@@ -58,37 +58,23 @@ PROTO SBForklift [
                 ]
                 endPoint Solid {
                   translation 0 0 0
-                  rotation -1 0 0 0
+                  rotation 0 0 1 1.5708
                   children [
-                    Transform {
-                      rotation 0 0 1 1.5708
-                      children [
-                        Shape {
-                          appearance PBRAppearance {
-                            baseColor 0 0.0051864 0
-                            roughness 0.3
-                            metalness 0
-                          }
-                          geometry Cylinder {
-                            height 0.021
-                            radius 0.05
-                            subdivision 32
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                  name "left wheel"
-                  boundingObject Transform {
-                    rotation 0 0 1 1.5708
-                    children [
-                      Cylinder {
+                    DEF WHEEL_GEO Shape {
+                      appearance PBRAppearance {
+                        baseColor 0 0.0051864 0
+                        roughness 0.3
+                        metalness 0
+                      }
+                      geometry Cylinder {
                         height 0.021
                         radius 0.05
                         subdivision 32
                       }
-                    ]
-                  }
+                    }
+                  ]
+                  name "left wheel"
+                  boundingObject USE WHEEL_GEO
                   physics Physics {
                     # density 20000
                   }
@@ -104,17 +90,7 @@ PROTO SBForklift [
                 rotation 0 0 1 1.5708
                 name "right wheel mount"
                 children [
-                  Shape {
-                    appearance PBRAppearance {
-                      baseColor 0 0.0051864 0
-                      roughness 0.3
-                      metalness 0
-                    }
-                    geometry DEF MOTOR_HOUSING Cylinder {
-                      height 0.07
-                      radius 0.015
-                    }
-                  }
+                  USE MOTOR_HOUSING
                 ]
                 boundingObject USE MOTOR_HOUSING
                 physics Physics {
@@ -136,37 +112,12 @@ PROTO SBForklift [
                 ]
                 endPoint Solid {
                   translation 0 0 0
-                  rotation -1 0 0 0
+                  rotation 0 0 1 1.5708
                   children [
-                    Transform {
-                      rotation 0 0 1 1.5708
-                      children [
-                        Shape {
-                          appearance PBRAppearance {
-                            baseColor 0 0.0051864 0
-                            roughness 0.3
-                            metalness 0
-                          }
-                          geometry Cylinder {
-                            height 0.021
-                            radius 0.05
-                            subdivision 32
-                          }
-                        }
-                      ]
-                    }
+                    USE WHEEL_GEO
                   ]
                   name "right wheel"
-                  boundingObject Transform {
-                    rotation 0 0 1 1.5708
-                    children [
-                      Cylinder {
-                        height 0.021
-                        radius 0.05
-                        subdivision 32
-                      }
-                    ]
-                  }
+                  boundingObject  USE WHEEL_GEO
                   physics Physics {
                     # density 20000
                   }
@@ -274,7 +225,7 @@ PROTO SBForklift [
                       }
                     }
                   ]
-                  boundingObject Sphere {
+                  boundingObject DEF CASTER_BALL_BOUND Sphere {
                     radius 0.008
                     # subdivision 2
                   }
@@ -311,43 +262,15 @@ PROTO SBForklift [
                   name "right caster"
                   translation 0 0 0
                   children [
-                    DEF CASTER_BALL Shape {
-                      appearance PBRAppearance {
-                        baseColor 0 0.0051864 0
-                        roughness 0.0
-                        metalness 0
-                      }
-                      geometry Sphere {
-                        radius 0.005
-                        # subdivision 2
-                      }
-                    }
+                    USE CASTER_BALL
                   ]
-                  boundingObject Sphere {
-                    radius 0.008
-                    # subdivision 2
-                  }
+                  boundingObject USE CASTER_BALL_BOUND
                   physics Physics {
                     # density 30000
                   }
                 }
               }
-              DEF CASTER_TOP Transform {
-                translation 0 0.01075 0
-                children [
-                  DEF CASTER_TOP_CYLINDER Shape {
-                    appearance PBRAppearance {
-                      baseColor 0 0.0051864 0
-                      roughness 0.5
-                      metalness 0
-                    }
-                    geometry Cylinder {
-                      height 0.0215
-                      radius 0.01
-                    }
-                  }
-                ]
-              }
+              USE CASTER_TOP
             ]
           }
         ]
@@ -359,32 +282,26 @@ PROTO SBForklift [
             translation 0 0 0.03
             rotation 0 0 1 1.5708
             children [
-              Shape {
+              DEF SUPPORT_ROD Shape {
                 appearance PBRAppearance {}
-                geometry DEF rod Cylinder {
+                geometry Cylinder {
                   radius 0.004
                   height 0.3
                 }
               }
             ]
             name "Support rod 1"
-            boundingObject USE rod
+            boundingObject USE SUPPORT_ROD
             physics Physics {}
           }
           Solid {
             translation 0 0 0.08
             rotation 0 0 1 1.5708
             children [
-              Shape {
-                appearance PBRAppearance {}
-                geometry DEF rod Cylinder {
-                  radius 0.004
-                  height 0.3
-                }
-              }
+              USE SUPPORT_ROD
             ]
             name "Support rod 2"
-            boundingObject USE rod
+            boundingObject USE SUPPORT_ROD
             physics Physics {}
           }
           DEF GRABBER_LEFT Transform {
@@ -406,7 +323,7 @@ PROTO SBForklift [
                 ]
                 endPoint Solid {
                   children [
-                    DEF GRIPPER_ARM_LEFT Transform {
+                    DEF GRIPPER_ARM Transform {
                       translation 0 0 0.067
                       children [
                         Shape {
@@ -419,7 +336,7 @@ PROTO SBForklift [
                     }
                   ]
                   name "Gripper slider 1"
-                  boundingObject USE GRIPPER_ARM_LEFT
+                  boundingObject USE GRIPPER_ARM
                   physics Physics {
                     density -1
                     mass 0.1
@@ -447,20 +364,10 @@ PROTO SBForklift [
                 ]
                 endPoint Solid {
                   children [
-                    DEF GRIPPER_ARM_RIGHT Transform {
-                      translation 0 0 0.067
-                      children [
-                        Shape {
-                          appearance PBRAppearance {}
-                          geometry Box {
-                            size 0.012 0.05 0.2
-                          }
-                        }
-                      ]
-                    }
+                    USE GRIPPER_ARM
                   ]
                   name "Gripper slider 2"
-                  boundingObject USE GRIPPER_ARM_RIGHT
+                  boundingObject USE GRIPPER_ARM
                   physics Physics {
                     density -1
                     mass 0.1

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -40,6 +40,7 @@ PROTO SBForklift [
                 ]
                 boundingObject USE MOTOR_HOUSING
                 physics Physics {
+                  density 8000  # steel
                 }
               }
               DEF LEFT_WHEEL HingeJoint {
@@ -94,6 +95,7 @@ PROTO SBForklift [
                 ]
                 boundingObject USE MOTOR_HOUSING
                 physics Physics {
+                  density 8000  # steel
                 }
               }
               DEF RIGHT_WHEEL HingeJoint {
@@ -196,6 +198,7 @@ PROTO SBForklift [
         ]
         boundingObject USE body_geo
         physics Physics {
+          # wood = ~700, leave at default
         }
       }
       DEF CASTERS Transform {
@@ -228,7 +231,7 @@ PROTO SBForklift [
                     # subdivision 2
                   }
                   physics Physics {
-                    # density 30000
+                    density 8000  # steel
                   }
                 }
               }
@@ -264,7 +267,7 @@ PROTO SBForklift [
                   ]
                   boundingObject USE CASTER_BALL_BOUND
                   physics Physics {
-                    # density 30000
+                    density 8000  # steel
                   }
                 }
               }
@@ -294,6 +297,7 @@ PROTO SBForklift [
             name "Support rod 1"
             boundingObject USE SUPPORT_ROD
             physics Physics {
+              density 8000  # steel
             }
           }
           Solid {
@@ -305,6 +309,7 @@ PROTO SBForklift [
             name "Support rod 2"
             boundingObject USE SUPPORT_ROD
             physics Physics {
+              density 8000  # steel
             }
           }
           DEF GRABBER_LEFT Transform {
@@ -373,8 +378,7 @@ PROTO SBForklift [
                   name "Gripper slider 1"
                   boundingObject USE GRIPPER_ARM
                   physics Physics {
-                    density -1
-                    mass 0.1
+                    # wood = ~700, leave at default
                   }
                 }
               }
@@ -410,8 +414,7 @@ PROTO SBForklift [
                   name "Gripper slider 2"
                   boundingObject USE GRIPPER_ARM
                   physics Physics {
-                    density -1
-                    mass 0.1
+                    # wood = ~700, leave at default
                   }
                 }
               }
@@ -491,6 +494,7 @@ PROTO SBForklift [
     model IS model
     boundingObject USE body_geo
     physics Physics {
+      # wood = ~700, leave at default
     }
     controller IS controller
     customData IS customData

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -327,6 +327,7 @@ PROTO SBForklift [
                     name "left gripper"
                     minPosition -0.01
                     maxPosition 0.124
+                    maxVelocity 0.5
                   }
                 ]
                 endPoint Solid {
@@ -399,6 +400,7 @@ PROTO SBForklift [
                     name "right gripper"
                     minPosition -0.01
                     maxPosition 0.124
+                    maxVelocity 0.5
                   }
                 ]
                 endPoint Solid {

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -127,82 +127,76 @@ PROTO SBForklift [
           }
         ]
       }
-      DEF BODY Transform {
-        translation 0 0 0.015
+      DEF BASE_BOARD Solid {
+        name "base"
         children [
-          DEF BASE_BOARD Solid {
-            translation 0 0.030 0
-            name "base"
+          DEF body_geo Group {
             children [
-              DEF body_geo Group {
+              DEF body_core Transform {
+                translation 0 0.030 -0.07
                 children [
-                  DEF body_core Transform {
-                    translation 0 0 -0.085
-                    children [
-                      Shape {
-                        appearance DEF BODY_COLOUR PBRAppearance {
-                          baseColor IS flagColour
-                          roughness 0.3
-                          metalness 0
-                        }
-                        geometry Box {
-                          size 0.17 0.012 0.11
-                        }
-                      }
-                    ]
+                  Shape {
+                    appearance DEF BODY_COLOUR PBRAppearance {
+                      baseColor IS flagColour
+                      roughness 0.3
+                      metalness 0
+                    }
+                    geometry Box {
+                      size 0.17 0.012 0.11
+                    }
                   }
-                  DEF body_front_spar Transform {
-                    translation 0 0 -0.015
-                    children [
-                      Shape {
-                        appearance USE BODY_COLOUR
-                        geometry Box {
-                          size 0.33 0.012 0.03
-                        }
-                      }
-                    ]
+                ]
+              }
+              DEF body_front_spar Transform {
+                translation 0 0.030 0
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.33 0.012 0.03
+                    }
                   }
-                  DEF body_rear_spar Transform {
-                    translation 0 0 -0.15
-                    children [
-                      Shape {
-                        appearance USE BODY_COLOUR
-                        geometry Box {
-                          size 0.23 0.012 0.02
-                        }
-                      }
-                    ]
+                ]
+              }
+              DEF body_rear_spar Transform {
+                translation 0 0.030 -0.135
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.23 0.012 0.02
+                    }
                   }
-                  DEF body_left_arm Transform {
-                    translation 0.1525 0.006 0.06
-                    children [
-                      Shape {
-                        appearance USE BODY_COLOUR
-                        geometry Box {
-                          size 0.025 0.024 0.12
-                        }
-                      }
-                    ]
+                ]
+              }
+              DEF body_left_arm Transform {
+                translation 0.1525 0.036 0.075
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.025 0.024 0.12
+                    }
                   }
-                  DEF body_right_arm Transform {
-                    translation -0.1525 0.006 0.06
-                    children [
-                      Shape {
-                        appearance USE BODY_COLOUR
-                        geometry Box {
-                          size 0.025 0.024 0.12
-                        }
-                      }
-                    ]
+                ]
+              }
+              DEF body_right_arm Transform {
+                translation -0.1525 0.036 0.075
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.025 0.024 0.12
+                    }
                   }
                 ]
               }
             ]
-            boundingObject USE body_geo
-            physics Physics {
-            }
           }
         ]
+        boundingObject USE body_geo
+        physics Physics {
+        }
       }
       DEF CASTERS Transform {
         translation 0 0.0025 0.1
@@ -495,12 +489,7 @@ PROTO SBForklift [
     ]
     name IS model
     model IS model
-    boundingObject Transform {
-      translation 0 0.030 0.015
-      children [
-        USE body_geo
-      ]
-    }
+    boundingObject USE body_geo
     physics Physics {
     }
     controller IS controller

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -32,16 +32,13 @@ PROTO SBForklift [
                       roughness 0.3
                       metalness 0
                     }
-                    geometry Cylinder {
+                    geometry DEF MOTOR_HOUSING Cylinder {
                       height 0.07
                       radius 0.015
                     }
                   }
                 ]
-                boundingObject Cylinder {
-                  height 0.07
-                  radius 0.015
-                }
+                boundingObject USE MOTOR_HOUSING
                 physics Physics {
                 }
               }
@@ -113,16 +110,13 @@ PROTO SBForklift [
                       roughness 0.3
                       metalness 0
                     }
-                    geometry Cylinder {
+                    geometry DEF MOTOR_HOUSING Cylinder {
                       height 0.07
                       radius 0.015
                     }
                   }
                 ]
-                boundingObject Cylinder {
-                  height 0.07
-                  radius 0.015
-                }
+                boundingObject USE MOTOR_HOUSING
                 physics Physics {
                 }
               }

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -28,7 +28,7 @@ PROTO SBForklift [
                 children [
                   DEF MOTOR_HOUSING Shape {
                     appearance PBRAppearance {
-                      baseColor 0 0.0051864 0
+                      baseColor 0.36 0.36 0.36
                       roughness 0.3
                       metalness 0
                     }
@@ -284,6 +284,8 @@ PROTO SBForklift [
             children [
               DEF SUPPORT_ROD Shape {
                 appearance PBRAppearance {
+                  baseColor 0.92 0.92 0.92
+                  roughness 0.3
                 }
                 geometry Cylinder {
                   radius 0.004
@@ -331,6 +333,9 @@ PROTO SBForklift [
                       children [
                         Shape {
                           appearance PBRAppearance {
+                            baseColor 0.25 0.35 0.235
+                            roughness 1
+                            metalness 0
                           }
                           geometry Box {
                             size 0.012 0.05 0.2

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -313,15 +313,15 @@ PROTO SBForklift [
               SliderJoint {
                 jointParameters JointParameters {
                   axis -1 0 0
-                  maxStop 0.135
-                  minStop 0
-                  position 0.01
+                  maxStop 0.124
+                  minStop -0.01
+                  position 0
                 }
                 device [
                   LinearMotor {
-                    name "Gripper Motor 1"
-                    minPosition 0.01
-                    maxPosition 0.134
+                    name "left gripper"
+                    minPosition -0.01
+                    maxPosition 0.124
                   }
                 ]
                 endPoint Solid {
@@ -386,15 +386,15 @@ PROTO SBForklift [
               SliderJoint {
                 jointParameters JointParameters {
                   axis 1 0 0
-                  maxStop 0.135
-                  minStop 0
-                  position 0.01
+                  maxStop 0.124
+                  minStop -0.01
+                  position 0
                 }
                 device [
                   LinearMotor {
-                    name "Gripper Motor 2"
-                    minPosition 0.01
-                    maxPosition 0.134
+                    name "right gripper"
+                    minPosition -0.01
+                    maxPosition 0.124
                   }
                 ]
                 endPoint Solid {

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -313,8 +313,8 @@ PROTO SBForklift [
               SliderJoint {
                 jointParameters JointParameters {
                   axis -1 0 0
-                  maxStop 0.134
-                  minStop 0.01
+                  maxStop 0.135
+                  minStop 0
                   position 0.01
                 }
                 device [
@@ -386,8 +386,8 @@ PROTO SBForklift [
               SliderJoint {
                 jointParameters JointParameters {
                   axis 1 0 0
-                  maxStop 0.134
-                  minStop 0.01
+                  maxStop 0.135
+                  minStop 0
                   position 0.01
                 }
                 device [

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -329,6 +329,9 @@ PROTO SBForklift [
                     maxPosition 0.124
                     maxVelocity 0.5
                   }
+                  PositionSensor {
+                    name "left gripper sensor"
+                  }
                 ]
                 endPoint Solid {
                   children [
@@ -401,6 +404,9 @@ PROTO SBForklift [
                     minPosition -0.01
                     maxPosition 0.124
                     maxVelocity 0.5
+                  }
+                  PositionSensor {
+                    name "right gripper sensor"
                   }
                 ]
                 endPoint Solid {

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -329,7 +329,7 @@ PROTO SBForklift [
                 endPoint Solid {
                   children [
                     DEF GRIPPER_ARM Transform {
-                      translation 0 0 0.067
+                      translation 0 0 0.065
                       children [
                         Shape {
                           appearance PBRAppearance {
@@ -340,6 +340,34 @@ PROTO SBForklift [
                           geometry Box {
                             size 0.012 0.05 0.2
                           }
+                        }
+                      ]
+                    }
+                    DEF SLIDE_BEARINGS Group {
+                      children [
+                        Transform {
+                          translation 0.001 0 -0.025
+                          rotation 0 0 1 1.5708
+                          children [
+                            DEF SLIDE_BEARING Shape {
+                              appearance PBRAppearance {
+                                baseColor 0.6471 0.4863 0
+                                emissiveColor 0.6471 0.4863 0
+                                emissiveIntensity 0.4
+                              }
+                              geometry Cylinder {
+                                height 0.016
+                                radius 0.008
+                              }
+                            }
+                          ]
+                        }
+                        Transform {
+                          translation 0.001 0 0.025
+                          rotation 0 0 1 1.5708
+                          children [
+                            USE SLIDE_BEARING
+                          ]
                         }
                       ]
                     }
@@ -374,6 +402,12 @@ PROTO SBForklift [
                 endPoint Solid {
                   children [
                     USE GRIPPER_ARM
+                    Transform {
+                      rotation 0 0 1 3.14
+                      children [
+                        USE SLIDE_BEARINGS
+                      ]
+                    }
                   ]
                   name "Gripper slider 2"
                   boundingObject USE GRIPPER_ARM

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -497,12 +497,12 @@ PROTO SBForklift [
           }
           DEF DISTANCE_SENSORS Group {
             children [
-              DEF left DistanceSensor {
-                translation 0.152 0.058 0
+              DEF front_left DistanceSensor {
+                translation 0.152 0.07 0.122
                 type "sonar"
                 numberOfRays 10
                 aperture 0.3
-                rotation 0 1 0 0
+                rotation 0 1 0 -1.5708
                 children [
                   DEF GEO_DS Transform {
                     rotation 1 -1 1 -2.0944
@@ -542,36 +542,6 @@ PROTO SBForklift [
                     ]
                   }
                 ]
-                name "Left DS"
-                lookupTable [
-                  0 0 0
-                  2 1000 0
-                ]
-              }
-              DEF right DistanceSensor {
-                translation -0.152 0.058 0
-                type "sonar"
-                numberOfRays 10
-                aperture 0.3
-                rotation 0 1 0 3.1416
-                children [
-                  USE GEO_DS
-                ]
-                name "Right DS"
-                lookupTable [
-                  0 0 0
-                  2 1000 0
-                ]
-              }
-              DEF front_left DistanceSensor {
-                translation 0.152 0.07 0.122
-                type "sonar"
-                numberOfRays 10
-                aperture 0.3
-                rotation 0 1 0 -1.5708
-                children [
-                  USE GEO_DS
-                ]
                 name "Front Left DS"
                 lookupTable [
                   0 0 0
@@ -593,7 +563,36 @@ PROTO SBForklift [
                   2 1000 0
                 ]
               }
-
+              DEF left DistanceSensor {
+                translation 0.152 0.058 0
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 0
+                children [
+                  USE GEO_DS
+                ]
+                name "Left DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
+              DEF right DistanceSensor {
+                translation -0.152 0.058 0
+                type "sonar"
+                numberOfRays 10
+                aperture 0.3
+                rotation 0 1 0 3.1416
+                children [
+                  USE GEO_DS
+                ]
+                name "Right DS"
+                lookupTable [
+                  0 0 0
+                  2 1000 0
+                ]
+              }
               DEF front DistanceSensor {
                 translation 0 0.055 0.011
                 type "sonar"

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -1,0 +1,565 @@
+#VRML_OBJ R2020a utf8
+PROTO SBForklift [
+  field SFVec3f translation 0 0 0
+  field SFRotation rotation 0 1 0 0
+  field SFString controller ""
+  field SFString model ""
+  field SFString customData ""
+  field SFColor flagColour 1 1 1
+  field MFString controllerArgs []
+]
+{
+  Robot {
+    selfCollision FALSE
+    translation IS translation
+    rotation IS rotation
+    controllerArgs IS controllerArgs
+    children [
+      DEF DRIVE_WHEELS Transform {
+        translation 0 0.05 -0.07
+        children [
+          DEF LEFT_WHEEL_CLUSTER Transform {
+            translation -0.101 0 0
+            children [
+              DEF LEFT_WHEEL_MOUNT Solid {
+                translation 0.04 0 0
+                rotation 0 0 1 1.5708
+                name "left wheel mount"
+                children [
+                  Shape {
+                    appearance PBRAppearance {
+                      baseColor 0 0.0051864 0
+                      roughness 0.3
+                      metalness 0
+                    }
+                    geometry Cylinder {
+                      height 0.07
+                      radius 0.015
+                    }
+                  }
+                ]
+                boundingObject Cylinder {
+                  height 0.07
+                  radius 0.015
+                }
+                physics Physics {
+                }
+              }
+              DEF LEFT_WHEEL HingeJoint {
+                jointParameters HingeJointParameters {
+                  position 0
+                  axis -1 0 0
+                }
+                device [
+                  RotationalMotor {
+                    name "left wheel"
+                    maxVelocity 12.3
+                  }
+                  PositionSensor {
+                    name "left wheel sensor"
+                  }
+                ]
+                endPoint Solid {
+                  translation 0 0 0
+                  rotation -1 0 0 0
+                  children [
+                    Transform {
+                      rotation 0 0 1 1.5708
+                      children [
+                        Shape {
+                          appearance PBRAppearance {
+                            baseColor 0 0.0051864 0
+                            roughness 0.3
+                            metalness 0
+                          }
+                          geometry Cylinder {
+                            height 0.021
+                            radius 0.05
+                            subdivision 32
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                  name "left wheel"
+                  boundingObject Transform {
+                    rotation 0 0 1 1.5708
+                    children [
+                      Cylinder {
+                        height 0.021
+                        radius 0.05
+                        subdivision 32
+                      }
+                    ]
+                  }
+                  physics Physics {
+                    # density 20000
+                  }
+                }
+              }
+            ]
+          }
+          DEF RIGHT_WHEEL_CLUSTER Transform {
+            translation 0.101 0 0
+            children [
+              DEF RIGHT_WHEEL_MOUNT Solid {
+                translation -0.04 0 0
+                rotation 0 0 1 1.5708
+                name "right wheel mount"
+                children [
+                  Shape {
+                    appearance PBRAppearance {
+                      baseColor 0 0.0051864 0
+                      roughness 0.3
+                      metalness 0
+                    }
+                    geometry Cylinder {
+                      height 0.07
+                      radius 0.015
+                    }
+                  }
+                ]
+                boundingObject Cylinder {
+                  height 0.07
+                  radius 0.015
+                }
+                physics Physics {
+                }
+              }
+              DEF RIGHT_WHEEL HingeJoint {
+                jointParameters HingeJointParameters {
+                  position 0
+                  axis -1 0 0
+                }
+                device [
+                  RotationalMotor {
+                    name "right wheel"
+                    maxVelocity 12.3
+                  }
+                  PositionSensor {
+                    name "right wheel sensor"
+                  }
+                ]
+                endPoint Solid {
+                  translation 0 0 0
+                  rotation -1 0 0 0
+                  children [
+                    Transform {
+                      rotation 0 0 1 1.5708
+                      children [
+                        Shape {
+                          appearance PBRAppearance {
+                            baseColor 0 0.0051864 0
+                            roughness 0.3
+                            metalness 0
+                          }
+                          geometry Cylinder {
+                            height 0.021
+                            radius 0.05
+                            subdivision 32
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                  name "right wheel"
+                  boundingObject Transform {
+                    rotation 0 0 1 1.5708
+                    children [
+                      Cylinder {
+                        height 0.021
+                        radius 0.05
+                        subdivision 32
+                      }
+                    ]
+                  }
+                  physics Physics {
+                    # density 20000
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+      DEF BODY Transform {
+        translation 0 0 0.015
+        children [
+          DEF BASE_BOARD Solid {
+            translation 0 0.030 0
+            name "base"
+            children [
+              DEF body_core Transform {
+                translation 0 0 -0.085
+                children [
+                  Shape {
+                    appearance DEF BODY_COLOUR PBRAppearance {
+                      baseColor IS flagColour
+                      roughness 0.3
+                      metalness 0
+                    }
+                    geometry Box {
+                      size 0.17 0.012 0.11
+                    }
+                  }
+                ]
+              }
+              DEF body_front_spar Transform {
+                translation 0 0 -0.015
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.33 0.012 0.03
+                    }
+                  }
+                ]
+              }
+              DEF body_rear_spar Transform {
+                translation 0 0 -0.15
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.23 0.012 0.02
+                    }
+                  }
+                ]
+              }
+              DEF body_left_arm Transform {
+                translation 0.1525 0.006 0.06
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.025 0.024 0.12
+                    }
+                  }
+                ]
+              }
+              DEF body_right_arm Transform {
+                translation -0.1525 0.006 0.06
+                children [
+                  Shape {
+                    appearance USE BODY_COLOUR
+                    geometry Box {
+                      size 0.025 0.024 0.12
+                    }
+                  }
+                ]
+              }
+            ]
+            boundingObject USE body_core
+            physics Physics {
+            }
+          }
+        ]
+      }
+      DEF CASTERS Transform {
+        translation 0 0.0025 0.1
+        children [
+          DEF LEFT_CASTER Transform {
+            translation -0.15 0 0
+            children [
+              DEF CASTER_JOINT BallJoint {
+                jointParameters BallJointParameters {
+                }
+                endPoint Solid {
+                  name "left caster"
+                  translation 0 0 0
+                  children [
+                    DEF CASTER_BALL Shape {
+                      appearance PBRAppearance {
+                        baseColor 0 0.0051864 0
+                        roughness 0.0
+                        metalness 0
+                      }
+                      geometry Sphere {
+                        radius 0.005
+                        # subdivision 2
+                      }
+                    }
+                  ]
+                  boundingObject Sphere {
+                    radius 0.008
+                    # subdivision 2
+                  }
+                  physics Physics {
+                    # density 30000
+                  }
+                }
+              }
+              DEF CASTER_TOP Transform {
+                translation 0 0.01075 0
+                children [
+                  DEF CASTER_TOP_CYLINDER Shape {
+                    appearance PBRAppearance {
+                      baseColor 0 0.0051864 0
+                      roughness 0.5
+                      metalness 0
+                    }
+                    geometry Cylinder {
+                      height 0.0215
+                      radius 0.01
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+          DEF RIGHT_CASTER Transform {
+            translation 0.15 0 0
+            children [
+              DEF CASTER_JOINT BallJoint {
+                jointParameters BallJointParameters {
+                }
+                endPoint Solid {
+                  name "right caster"
+                  translation 0 0 0
+                  children [
+                    DEF CASTER_BALL Shape {
+                      appearance PBRAppearance {
+                        baseColor 0 0.0051864 0
+                        roughness 0.0
+                        metalness 0
+                      }
+                      geometry Sphere {
+                        radius 0.005
+                        # subdivision 2
+                      }
+                    }
+                  ]
+                  boundingObject Sphere {
+                    radius 0.008
+                    # subdivision 2
+                  }
+                  physics Physics {
+                    # density 30000
+                  }
+                }
+              }
+              DEF CASTER_TOP Transform {
+                translation 0 0.01075 0
+                children [
+                  DEF CASTER_TOP_CYLINDER Shape {
+                    appearance PBRAppearance {
+                      baseColor 0 0.0051864 0
+                      roughness 0.5
+                      metalness 0
+                    }
+                    geometry Cylinder {
+                      height 0.0215
+                      radius 0.01
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      DEF GRABBER Transform {
+        translation 0 0.036 0
+        children [
+          Solid {
+            translation 0 0 0.03
+            rotation 0 0 1 1.5708
+            children [
+              Shape {
+                appearance PBRAppearance {}
+                geometry DEF rod Cylinder {
+                  radius 0.004
+                  height 0.3
+                }
+              }
+            ]
+            name "Support rod 1"
+            boundingObject USE rod
+            physics Physics {}
+          }
+          Solid {
+            translation 0 0 0.08
+            rotation 0 0 1 1.5708
+            children [
+              Shape {
+                appearance PBRAppearance {}
+                geometry DEF rod Cylinder {
+                  radius 0.004
+                  height 0.3
+                }
+              }
+            ]
+            name "Support rod 2"
+            boundingObject USE rod
+            physics Physics {}
+          }
+          DEF GRABBER_LEFT Transform {
+            translation 0.13 0 0.055
+            children [
+              SliderJoint {
+                jointParameters JointParameters {
+                  axis -1 0 0
+                  maxStop 0.134
+                  minStop 0.01
+                  position 0.01
+                }
+                device [
+                  LinearMotor {
+                    name "Gripper Motor 1"
+                    minPosition 0.01
+                    maxPosition 0.134
+                  }
+                ]
+                endPoint Solid {
+                  children [
+                    DEF GRIPPER_ARM_LEFT Transform {
+                      translation 0 0 0.067
+                      children [
+                        Shape {
+                          appearance PBRAppearance {}
+                          geometry Box {
+                            size 0.012 0.05 0.2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                  name "Gripper slider 1"
+                  boundingObject USE GRIPPER_ARM_LEFT
+                  physics Physics {
+                    density -1
+                    mass 0.1
+                  }
+                }
+              }
+            ]
+          }
+          DEF GRABBER_RIGHT Transform {
+            translation -0.13 0 0.055
+            children [
+              SliderJoint {
+                jointParameters JointParameters {
+                  axis 1 0 0
+                  maxStop 0.134
+                  minStop 0.01
+                  position 0.01
+                }
+                device [
+                  LinearMotor {
+                    name "Gripper Motor 2"
+                    minPosition 0.01
+                    maxPosition 0.134
+                  }
+                ]
+                endPoint Solid {
+                  children [
+                    DEF GRIPPER_ARM_RIGHT Transform {
+                      translation 0 0 0.067
+                      children [
+                        Shape {
+                          appearance PBRAppearance {}
+                          geometry Box {
+                            size 0.012 0.05 0.2
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                  name "Gripper slider 2"
+                  boundingObject USE GRIPPER_ARM_RIGHT
+                  physics Physics {
+                    density -1
+                    mass 0.1
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+      # DEF flag_pole Solid {
+      #   translation 0 0.25 0
+      #   children [
+      #     LED {
+      #       translation 0 0.1 -0.085
+      #       children [
+      #         Shape {
+      #           appearance PBRAppearance {
+      #             metalness 0
+      #             occlusionMapStrength 130
+      #             emissiveIntensity 10
+      #             baseColor IS flagColour
+      #           }
+      #           geometry Box {
+      #             size 0.005 0.1 0.15
+      #           }
+      #         }
+      #       ]
+      #       name "flag"
+      #       color [
+      #         0.1 0.1 0.7
+      #         1 0.5 0.9
+      #         0.8 0.8 0.1
+      #         0.1 0.7 0.1
+      #       ]
+      #     }
+      #     Shape {
+      #       appearance PBRAppearance {
+      #         baseColor 0.0705882 0.0705882 0.0705882
+      #         roughness 0.4
+      #         metalness 0
+      #       }
+      #       geometry DEF flag_pole Cylinder {
+      #         height 0.3
+      #         radius 0.01
+      #       }
+      #     }
+      #   ]
+      #   boundingObject USE flag_pole
+      #   name "flag pole"
+      #   physics Physics {
+      #   }
+      # }
+      DEF SENSORS Transform {
+        translation 0 0 0
+        children [
+          Receiver {
+            type "radio"
+            name "robot receiver"
+            bufferSize 30
+            channel 1
+            directionNoise 0.05
+            signalStrengthNoise 0.03
+          }
+          Emitter {
+            type "radio"
+            name "robot emitter"
+            range 0.5
+            maxRange 0.5
+            channel 2
+          }
+          Compass {
+            name "robot compass"
+            rotation 0 1 0 0
+          }
+        ]
+      }
+    ]
+    name IS model
+    model IS model
+    boundingObject Transform {
+      translation 0 0.030 -0.065
+      children [
+        Shape {
+          geometry Box {
+            size 0.17 0.012 0.16
+          }
+        }
+      ]
+    }
+    physics Physics {
+    }
+    controller IS controller
+    customData IS customData
+  }
+}

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -35,7 +35,7 @@ DEF ROBOT-0 SBForklift {
   controllerArgs "0"
 }
 DEF ROBOT-1 SBForklift {
-  translation 0 0 7
+  translation 0 0.005 7
   rotation 0 1 0 3.14
   controller "sr_controller"
   model "Robot1"

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -26,9 +26,9 @@ DEF AMBIENT Background {
 }
 
 # Updating colours? Update `territory_controller.py`
-DEF ROBOT-0 SRRobot {
+DEF ROBOT-0 SBForklift {
   translation 0 0.005 -7
-  rotation 0 1 0 3.14
+  rotation 0 1 0 0
   controller "sr_controller"
   model "Robot0"
   flagColour 1 0 1

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -26,17 +26,17 @@ DEF AMBIENT Background {
 }
 
 # Updating colours? Update `territory_controller.py`
-DEF ROBOT-0 SBForklift {
+DEF ROBOT-0 SRRobot {
   translation 0 0.005 -7
-  rotation 0 1 0 0
+  rotation 0 1 0 3.14
   controller "sr_controller"
   model "Robot0"
   flagColour 1 0 1
   controllerArgs "0"
 }
-DEF ROBOT-1 SRRobot {
+DEF ROBOT-1 SBForklift {
   translation 0 0 7
-  rotation 0 1 0 0
+  rotation 0 1 0 3.14
   controller "sr_controller"
   model "Robot1"
   flagColour 1 1 0

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -26,9 +26,9 @@ DEF AMBIENT Background {
 }
 
 # Updating colours? Update `territory_controller.py`
-DEF ROBOT-0 SRRobot {
-  translation 0 0 -7
-  rotation 0 1 0 3.14
+DEF ROBOT-0 SBForklift {
+  translation 0 0.005 -7
+  rotation 0 1 0 0
   controller "sr_controller"
   model "Robot0"
   flagColour 1 0 1


### PR DESCRIPTION
~This only adds the model and doesn't alter the modules to connect things up in the code.~
This PR is primarily about adding the model but makes minor tweaks to the modules to allow the simulation to be run.

Currently the attached sensors are:
- radio transmitter/receiver
- compass
- ultrasound sensors
- rear bump sensor
- position sensors on the grabber and wheels

~The complete list of sensors needs to be decided (#3).~

Forklift bot (left) compared to previous SR robt (right)
![Arena_31](https://user-images.githubusercontent.com/10937272/125452631-972075f1-578d-4943-b737-71c1d70f6861.png)

fixes sourcebots/competition-simulator#5