### PR TITLE
Add Webots 2021b support, drop Webots 2020b-rev1 support

### DIFF
--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        webots-version: ["2020b-rev1", "2021a"]
+        webots-version: ["2021a", '2021b']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/.github/workflows/run-match.yml
+++ b/.github/workflows/run-match.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        webots-version: ["2021a", '2021b']
+        webots-version: ['2021b']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.7

--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -176,24 +176,8 @@ def remove_unused_robots(supervisor: Supervisor) -> None:
 
 
 def get_simulation_run_mode(supervisor: Supervisor) -> 'SimulationMode':
-    # webots 2020b is buggy and can raise TypeError when getDevice is passed a str
-    if supervisor.getDevice("2021a-compatibility") is None:
-        print(
-            "This simulator is running a different version of Webots to the "
-            "one that will be used for the next official competition matches "
-            "(You can check the docs to see which version will be used)",
-            file=sys.stderr,
-        )
-        print(
-            "As such it is possible that some behaviour may not "
-            "match that of the official competition matches",
-            file=sys.stderr,
-        )
-        # we are running version 2020b so the old command is used
-        return Supervisor.SIMULATION_MODE_RUN
-    else:
-        # webots-2021a removed the RUN mode and now uses FAST
-        return Supervisor.SIMULATION_MODE_FAST
+    # webots-2021a removed the RUN mode and now uses FAST
+    return Supervisor.SIMULATION_MODE_FAST
 
 
 def inform_start(node: Node) -> None:

--- a/modules/sr/robot/utils.py
+++ b/modules/sr/robot/utils.py
@@ -1,17 +1,6 @@
-from typing import Type, TypeVar, Optional
+from typing import Type, TypeVar
 
-from controller import (
-    LED,
-    Motor,
-    Robot,
-    Device,
-    Compass,
-    Display,
-    Emitter,
-    Receiver,
-    TouchSensor,
-    DistanceSensor,
-)
+from controller import Robot, Device
 
 TDevice = TypeVar('TDevice', bound=Device)
 
@@ -28,30 +17,7 @@ def map_to_range(
 
 
 def get_robot_device(robot: Robot, name: str, kind: Type[TDevice]) -> TDevice:
-    device: Optional[Device] = None
-    try:
-        # webots 2020b is buggy and always raises TypeError when passed a str,
-        # however we're aiming to be forwards compatible with 2021a, so try this first.
-        device = robot.getDevice(name)
-    except TypeError:
-        pass
-    if device is None:  # webots 2020b always returns None when not raising TypeError
-        if kind is Emitter:
-            device = robot.getEmitter(name)
-        elif kind is Receiver:
-            device = robot.getReceiver(name)
-        elif kind is Motor:
-            device = robot.getMotor(name)
-        elif kind is LED:
-            device = robot.getLED(name)
-        elif kind is DistanceSensor:
-            device = robot.getDistanceSensor(name)
-        elif kind is TouchSensor:
-            device = robot.getTouchSensor(name)
-        elif kind is Compass:
-            device = robot.getCompass(name)
-        elif kind is Display:
-            device = robot.getDisplay(name)
+    device = robot.getDevice(name)
     if not isinstance(device, kind):
         raise TypeError
     return device

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -1,4 +1,4 @@
-#VRML_OBJ R2020a utf8
+#VRML_OBJ R2021b utf8
 PROTO SBForklift [
   field SFVec3f translation 0 0 0
   field SFRotation rotation 0 1 0 0

--- a/protos/Robot_Echo/SRRobot.proto
+++ b/protos/Robot_Echo/SRRobot.proto
@@ -1,4 +1,4 @@
-#VRML_OBJ R2020a utf8
+#VRML_OBJ R2021b utf8
 PROTO SRRobot [
   field SFVec3f translation 0 0 0
   field SFRotation rotation 0 1 0 0

--- a/protos/Territories/SRLink.proto
+++ b/protos/Territories/SRLink.proto
@@ -1,4 +1,4 @@
-#VRML_OBJ R2020a utf8
+#VRML_OBJ R2021b utf8
 PROTO SRLink [
   field SFVec3f translation 0 0 0
   field SFRotation rotation 0 1 0 0

--- a/protos/Territories/SRTerritory.proto
+++ b/protos/Territories/SRTerritory.proto
@@ -1,4 +1,4 @@
-#VRML_OBJ R2020a utf8
+#VRML_OBJ R2021b utf8
 # tags: static
 
 PROTO SRTerritory [

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -67,13 +67,6 @@ Robot {
   description "A supervisor 'robot' to help run the competition."
   controller "competition_supervisor"
   supervisor TRUE
-  children [
-    # this is a hack to detect if we are running on version 2020b
-    Connector {
-      name "2021a-compatibility"
-      type "passive"
-    }
-  ]
 }
 Robot {
   rotation 0 1 0 -1.5708

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -1,4 +1,4 @@
-#VRML_SIM R2020b utf8
+#VRML_SIM R2021b utf8
 WorldInfo {
   coordinateSystem "NUE"
   basicTimeStep 8


### PR DESCRIPTION
Since we will have total control over the simulator being used we can tightly control which version is used. Limiting this to a single version removes the need for version compatibility hacks and reduces the time CI takes.

Webots 2021b changes the default location of provided textures to be http links instaed of local files, thus it warns you to update older proto files at launch.