### PR TITLE
Optimise forklift simulation performance

### DIFF
--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -35,6 +35,7 @@ PROTO SBForklift [
                     geometry Cylinder {
                       height 0.07
                       radius 0.015
+                      subdivision 12
                     }
                   }
                 ]
@@ -247,6 +248,8 @@ PROTO SBForklift [
                     geometry Cylinder {
                       height 0.0215
                       radius 0.01
+                      subdivision 12
+                      top FALSE
                     }
                   }
                 ]
@@ -291,6 +294,9 @@ PROTO SBForklift [
                 geometry Cylinder {
                   radius 0.004
                   height 0.3
+                  subdivision 12
+                  top FALSE
+                  bottom FALSE
                 }
               }
             ]
@@ -365,6 +371,7 @@ PROTO SBForklift [
                               geometry Cylinder {
                                 height 0.016
                                 radius 0.008
+                                subdivision 16
                               }
                             }
                           ]
@@ -465,6 +472,8 @@ PROTO SBForklift [
             geometry DEF flag_pole Cylinder {
               height 0.2
               radius 0.01
+              subdivision 12
+              bottom FALSE
             }
           }
         ]
@@ -528,6 +537,8 @@ PROTO SBForklift [
                             geometry Cylinder {
                               radius 0.008
                               height 0.012
+                              subdivision 16
+                              bottom FALSE
                             }
                           }
                         ]

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -39,7 +39,9 @@ PROTO SBForklift [
                     }
                   }
                 ]
-                boundingObject USE MOTOR_HOUSING
+                boundingObject DEF MOTOR_HOUSING_GEO Box {
+                  size 0.03 0.07 0.03
+                }
                 physics Physics {
                   density 8000  # steel
                 }
@@ -94,7 +96,7 @@ PROTO SBForklift [
                 children [
                   USE MOTOR_HOUSING
                 ]
-                boundingObject USE MOTOR_HOUSING
+                boundingObject USE MOTOR_HOUSING_GEO
                 physics Physics {
                   density 8000  # steel
                 }
@@ -301,7 +303,9 @@ PROTO SBForklift [
               }
             ]
             name "Support rod 1"
-            boundingObject USE SUPPORT_ROD
+            boundingObject DEF SUPPORT_ROD_GEO Box {
+              size 0.007 0.3 0.007
+            }
             physics Physics {
               density 8000  # steel
             }
@@ -313,7 +317,7 @@ PROTO SBForklift [
               USE SUPPORT_ROD
             ]
             name "Support rod 2"
-            boundingObject USE SUPPORT_ROD
+            boundingObject USE SUPPORT_ROD_GEO
             physics Physics {
               density 8000  # steel
             }
@@ -477,7 +481,9 @@ PROTO SBForklift [
             }
           }
         ]
-        boundingObject USE flag_pole
+        boundingObject Box {
+          size 0.02 0.2 0.02
+        }
         name "flag pole"
         physics Physics {
         }

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -199,10 +199,6 @@ PROTO SBForklift [
             ]
           }
         ]
-        boundingObject USE body_geo
-        physics Physics {
-          # wood = ~700, leave at default
-        }
       }
       DEF CASTERS Transform {
         translation 0 0.0025 0.1

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -55,6 +55,7 @@ PROTO SBForklift [
                   RotationalMotor {
                     name "left wheel"
                     maxVelocity 12.3
+                    sound ""
                   }
                   PositionSensor {
                     name "left wheel sensor"
@@ -110,6 +111,7 @@ PROTO SBForklift [
                   RotationalMotor {
                     name "right wheel"
                     maxVelocity 12.3
+                    sound ""
                   }
                   PositionSensor {
                     name "right wheel sensor"
@@ -334,6 +336,7 @@ PROTO SBForklift [
                     minPosition -0.01
                     maxPosition 0.124
                     maxVelocity 0.5
+                    sound ""
                   }
                   PositionSensor {
                     name "left gripper sensor"
@@ -411,6 +414,7 @@ PROTO SBForklift [
                     minPosition -0.01
                     maxPosition 0.124
                     maxVelocity 0.5
+                    sound ""
                   }
                   PositionSensor {
                     name "right gripper sensor"


### PR DESCRIPTION
I've noticed some performance reduction since adding the forklift model to the arena, this mostly negates that reduction.
Generally it just simplifies the bounding object and reduces the subdivision of cylinders.

Further optimisation can be done once everything else is completed.