### PR TITLE
Add the crane robot model to the simulator

### DIFF
--- a/modules/sr/robot/motor.py
+++ b/modules/sr/robot/motor.py
@@ -25,11 +25,14 @@ def init_motor_array(webot: Robot, robot_type: RobotType) -> List[Motor]:
             ),
         ]
     else:
-        # TODO: placeholder crane motor board
         return [
             Motor(
-                Wheel(webot, 'left wheel'),
-                Wheel(webot, 'right wheel'),
+                LinearMotor(webot, "bridge motor"),
+                LinearMotor(webot, "trolley motor"),
+            ),
+            Motor(
+                LinearMotor(webot, "hoist motor"),
+                None,
             ),
         ]
 

--- a/modules/sr/robot/ruggeduino.py
+++ b/modules/sr/robot/ruggeduino.py
@@ -9,6 +9,8 @@ from sr.robot.output_frequency_limiter import OutputFrequencyLimiter
 
 
 def init_ruggeduino_array(webot: Robot, robot_type: RobotType) -> List[Ruggeduino]:
+    dist_sensor_names: List[str]
+    switch_names: List[str]
     led_names: List[str]
 
     # The names in these arrays correspond to the names given to devices in Webots
@@ -35,27 +37,12 @@ def init_ruggeduino_array(webot: Robot, robot_type: RobotType) -> List[Ruggeduin
             # "led 6",
         ]
     else:
-        # TODO: placeholder crane ruggeduino
         dist_sensor_names = [
-            # Updating these? Also update controllers/example_controller/keyboard_controller.py
-            "Front Left DS",
-            "Front Right DS",
-            "Left DS",
-            "Right DS",
-            "Back Left DS",
-            "Back Right DS",
         ]
         switch_names = [
-            "front bump sensor",
-            "back bump sensor",
+            "hook touch sensor",
         ]
         led_names = [
-            "led 1",
-            "led 2",
-            "led 3",
-            "led 4",
-            "led 5",
-            "led 6",
         ]
 
     analogue_input_array = [DistanceSensor(webot, name) for name in dist_sensor_names]

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -141,6 +141,22 @@ PROTO SBCrane [
                                       shearStrength 10
                                       name "Crane Connector"
                                     }
+                                    Receiver {
+                                      type "radio"
+                                      name "robot receiver"
+                                      bufferSize 30
+                                      channel 1
+                                      directionNoise 0.05
+                                      signalStrengthNoise 0.03
+                                    }
+                                    TouchSensor {
+                                      translation 0 -0.025 0
+                                      rotation 0 1 0 0
+                                      name "hook touch sensor"
+                                      boundingObject Box {
+                                        size 0.05 0.01 0.05
+                                      }
+                                    }
                                   ]
                                   boundingObject USE hook_geo
                                   physics Physics {

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -83,59 +83,78 @@ PROTO SBCrane [
                       size 0.1 0.05 0.1
                     }
                   }
-                  SliderJoint {
-                    jointParameters JointParameters {
-                      axis 0 -1 0
-                      minStop -0.01
-                      maxStop IS maxY
-                      position IS initY
+                  BallJoint {  # allow the cable to tilt
+                    jointParameters BallJointParameters {
                     }
-                    device [
-                      LinearMotor {
-                        name "hoist motor"
-                        minPosition 0
-                        maxPosition IS maxY
-                        maxVelocity 2
-                        sound ""
-                        muscles Muscle {
-                          volume 1e-04
-                          startOffset 0 0.12 0
-                          endOffset 0 -0.025 0
-                        }
-                      }
-                      PositionSensor {
-                        name "hoist position sensor"
-                      }
-                    ]
                     endPoint Solid {
-                      translation 0 -0.05 0
                       children [
-                        Shape {
-                          appearance PBRAppearance {
-                            baseColor IS flagColour
-                            roughness 1
-                            metalness 0
+                        SliderJoint {
+                          jointParameters JointParameters {
+                            axis 0 -1 0
+                            minStop -0.01
+                            maxStop IS maxY
+                            position IS initY
                           }
-                          geometry DEF hook_geo Box {
-                            size 0.05 0.05 0.05
+                          device [
+                            LinearMotor {
+                              name "hoist motor"
+                              minPosition 0
+                              maxPosition IS maxY
+                              maxVelocity 2
+                              sound ""
+                              muscles Muscle {
+                                volume 1e-04
+                                startOffset 0 0.12 0
+                                endOffset 0 -0.025 0
+                              }
+                            }
+                            PositionSensor {
+                              name "hoist position sensor"
+                            }
+                          ]
+                          endPoint Solid {
+                            translation 0 -0.025 0
+                            children [
+                              BallJoint {  # allow the hook to tilt
+                                jointParameters BallJointParameters {
+                                }
+                                endPoint Solid {
+                                  translation 0 -0.025 0
+                                  children [
+                                    Shape {
+                                      appearance PBRAppearance {
+                                        baseColor IS flagColour
+                                        roughness 1
+                                        metalness 0
+                                      }
+                                      geometry DEF hook_geo Box {
+                                        size 0.05 0.05 0.05
+                                      }
+                                    }
+                                    Connector {
+                                      type "active"
+                                      distanceTolerance 0.1
+                                      axisTolerance 0.7854
+                                      rotationTolerance 0
+                                      numberOfRotations 0
+                                      tensileStrength 10
+                                      shearStrength 10
+                                      name "Crane Connector"
+                                    }
+                                  ]
+                                  boundingObject USE hook_geo
+                                  physics Physics {
+                                    # density 8000  # steel
+                                  }
+                                  name "hook"
+                                }
+                              }
+                            ]
+                            name "hook pivot"
                           }
-                        }
-                        Connector {
-                          type "active"
-                          distanceTolerance 0.1
-                          axisTolerance 0.7854
-                          rotationTolerance 0
-                          numberOfRotations 0
-                          tensileStrength 10
-                          shearStrength 10
-                          name "Crane Connector"
                         }
                       ]
-                      boundingObject USE hook_geo
-                      physics Physics {
-                        # density 8000  # steel
-                      }
-                      name "hook"
+                      name "cable pivot"
                     }
                   }
                 ]

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -117,6 +117,7 @@ PROTO SBCrane [
                             children [
                               BallJoint {  # allow the hook to tilt
                                 jointParameters BallJointParameters {
+                                  dampingConstant 0.5
                                 }
                                 endPoint Solid {
                                   translation 0 -0.025 0
@@ -139,8 +140,8 @@ PROTO SBCrane [
                                       axisTolerance 0.7854
                                       rotationTolerance 0
                                       numberOfRotations 0
-                                      tensileStrength 30
-                                      shearStrength 10
+                                      tensileStrength 35
+                                      shearStrength 20
                                       snap FALSE
                                       name "Crane Connector"
                                       unilateralUnlock TRUE

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -9,7 +9,7 @@ PROTO SBCrane [
   field SFColor flagColour 1 1 1
   field MFString controllerArgs []
   field SFVec3f initPos 0 0 0
-  field SFFloat maxY 2
+  field SFFloat maxY 1.5
 ]
 {
   Robot {

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -180,6 +180,15 @@ PROTO SBCrane [
                               }
                             ]
                             name "hook pivot"
+                            physics Physics {
+                              density -1
+                              mass 0.1
+                              centerOfMass 0 0 0
+                              inertiaMatrix [
+                                1 1 1
+                                0 0 0
+                              ]
+                            }
                           }
                         }
                       ]

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -117,7 +117,21 @@ PROTO SBCrane [
                             children [
                               BallJoint {  # allow the hook to tilt
                                 jointParameters BallJointParameters {
-                                  dampingConstant 0.5
+                                  minStop -0.7854
+                                  maxStop 0.7854
+                                  dampingConstant 0.05
+                                }
+                                jointParameters2 JointParameters {
+                                  axis 1 0 0
+                                  minStop -0.7854
+                                  maxStop 0.7854
+                                  dampingConstant 0.05
+                                }
+                                jointParameters3 JointParameters {
+                                  axis 0 0 1
+                                  minStop -0.7854
+                                  maxStop 0.7854
+                                  dampingConstant 0.05
                                 }
                                 endPoint Solid {
                                   translation 0 -0.025 0

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -149,6 +149,13 @@ PROTO SBCrane [
                                       directionNoise 0.05
                                       signalStrengthNoise 0.03
                                     }
+                                    Emitter {
+                                      type "radio"
+                                      name "robot emitter"
+                                      range 0.5
+                                      maxRange 0.5
+                                      channel 2
+                                    }
                                     TouchSensor {
                                       translation 0 -0.025 0
                                       rotation 0 1 0 0

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -1,0 +1,154 @@
+#VRML_OBJ R2021b utf8
+PROTO SBCrane [
+  field SFVec3f translation 0 0 0
+  field SFRotation rotation 0 1 0 0
+  field SFString controller ""
+  field SFString model ""
+  field SFString customData ""
+  field SFColor flagColour 1 1 1
+  field MFString controllerArgs []
+  field SFFloat initX 0
+  field SFFloat initY 0
+  field SFFloat initZ 0
+  field SFFloat maxY 2
+]
+{
+  Robot {
+    selfCollision FALSE
+    translation IS translation
+    rotation IS rotation
+    controllerArgs IS controllerArgs
+    children [
+      SliderJoint {
+        jointParameters JointParameters {
+          axis 1 0 0
+          minStop -1.75
+          maxStop 1.75
+          position IS initX
+        }
+        device [
+          LinearMotor {
+            name "bridge motor"
+            minPosition -1.75
+            maxPosition 1.75
+            maxVelocity 2
+            sound ""
+          }
+          PositionSensor {
+            name "bridge position sensor"
+          }
+        ]
+        endPoint Solid {
+          children [
+            Shape {
+              appearance PBRAppearance {
+                baseColor IS flagColour
+                roughness 1
+                metalness 0
+              }
+              geometry Box {
+                size 0.1 0.1 1.5
+              }
+            }
+            SliderJoint {
+              jointParameters JointParameters {
+                axis 0 0 1
+                minStop -0.7
+                maxStop 0.7
+                position IS initZ
+              }
+              device [
+                LinearMotor {
+                  name "trolley motor"
+                  minPosition -0.7
+                  maxPosition 0.7
+                  maxVelocity 2
+                  sound ""
+                }
+                PositionSensor {
+                  name "trolley position sensor"
+                }
+              ]
+              endPoint Solid {
+                translation 0 -0.075 0
+                children [
+                  Shape {
+                    appearance PBRAppearance {
+                      baseColor 0.35 0.35 0.35
+                      roughness 1
+                      metalness 0
+                    }
+                    geometry Box {
+                      size 0.1 0.05 0.1
+                    }
+                  }
+                  SliderJoint {
+                    jointParameters JointParameters {
+                      axis 0 -1 0
+                      minStop -0.01
+                      maxStop IS maxY
+                      position IS initY
+                    }
+                    device [
+                      LinearMotor {
+                        name "hoist motor"
+                        minPosition 0
+                        maxPosition IS maxY
+                        maxVelocity 2
+                        sound ""
+                        muscles Muscle {
+                          volume 1e-04
+                          startOffset 0 0.12 0
+                          endOffset 0 -0.025 0
+                        }
+                      }
+                      PositionSensor {
+                        name "hoist position sensor"
+                      }
+                    ]
+                    endPoint Solid {
+                      translation 0 -0.05 0
+                      children [
+                        Shape {
+                          appearance PBRAppearance {
+                            baseColor IS flagColour
+                            roughness 1
+                            metalness 0
+                          }
+                          geometry DEF hook_geo Box {
+                            size 0.05 0.05 0.05
+                          }
+                        }
+                        Connector {
+                          type "active"
+                          distanceTolerance 0.1
+                          axisTolerance 0.7854
+                          rotationTolerance 0
+                          numberOfRotations 0
+                          tensileStrength 10
+                          shearStrength 10
+                          name "Crane Connector"
+                        }
+                      ]
+                      boundingObject USE hook_geo
+                      physics Physics {
+                        # density 8000  # steel
+                      }
+                      name "hook"
+                    }
+                  }
+                ]
+                name "trolley"
+              }
+            }
+          ]
+          name "bridge beam"
+        }
+      }
+    ]
+    name IS model
+    model IS model
+    controller IS controller
+    customData IS customData
+  }
+}

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -1,4 +1,5 @@
 #VRML_OBJ R2021b utf8
+# tags: static
 PROTO SBCrane [
   field SFVec3f translation 0 0 0
   field SFRotation rotation 0 1 0 0
@@ -7,9 +8,7 @@ PROTO SBCrane [
   field SFString customData ""
   field SFColor flagColour 1 1 1
   field MFString controllerArgs []
-  field SFFloat initX 0
-  field SFFloat initY 0
-  field SFFloat initZ 0
+  field SFVec3f initPos 0 0 0
   field SFFloat maxY 2
 ]
 {
@@ -24,7 +23,7 @@ PROTO SBCrane [
           axis 1 0 0
           minStop -1.7
           maxStop 1.7
-          position IS initX
+          position %{=fields.initPos.value.x}%
         }
         device [
           LinearMotor {
@@ -39,7 +38,8 @@ PROTO SBCrane [
           }
         ]
         endPoint Solid {
-          translation 0 0.15 0  # Shift origin to be the lower face of the hook shape
+          # Shift origin to be the lower face of the hook shape
+          translation %{=fields.initPos.value.x}% 0.15 0
           children [
             Shape {
               appearance PBRAppearance {
@@ -56,7 +56,7 @@ PROTO SBCrane [
                 axis 0 0 1
                 minStop -0.7
                 maxStop 0.7
-                position IS initZ
+                position %{=fields.initPos.value.z}%
               }
               device [
                 LinearMotor {
@@ -71,7 +71,7 @@ PROTO SBCrane [
                 }
               ]
               endPoint Solid {
-                translation 0 -0.075 0
+                translation 0 -0.075 %{=fields.initPos.value.z}%
                 children [
                   Shape {
                     appearance PBRAppearance {
@@ -93,7 +93,7 @@ PROTO SBCrane [
                             axis 0 -1 0
                             minStop -0.01
                             maxStop IS maxY
-                            position IS initY
+                            position %{=fields.initPos.value.y}%
                           }
                           device [
                             LinearMotor {
@@ -113,7 +113,7 @@ PROTO SBCrane [
                             }
                           ]
                           endPoint Solid {
-                            translation 0 -0.025 0
+                            translation 0 %{=-0.025-fields.initPos.value.y}% 0
                             children [
                               BallJoint {  # allow the hook to tilt
                                 jointParameters BallJointParameters {

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -132,14 +132,19 @@ PROTO SBCrane [
                                       }
                                     }
                                     Connector {
+                                      translation 0 -0.03 0
+                                      rotation 1 0 0 1.5708
                                       type "active"
                                       distanceTolerance 0.1
                                       axisTolerance 0.7854
                                       rotationTolerance 0
                                       numberOfRotations 0
-                                      tensileStrength 10
+                                      tensileStrength 30
                                       shearStrength 10
+                                      snap FALSE
                                       name "Crane Connector"
+                                      unilateralUnlock TRUE
+                                      unilateralLock TRUE
                                     }
                                     Receiver {
                                       type "radio"

--- a/protos/Crane/SBCrane.proto
+++ b/protos/Crane/SBCrane.proto
@@ -22,15 +22,15 @@ PROTO SBCrane [
       SliderJoint {
         jointParameters JointParameters {
           axis 1 0 0
-          minStop -1.75
-          maxStop 1.75
+          minStop -1.7
+          maxStop 1.7
           position IS initX
         }
         device [
           LinearMotor {
             name "bridge motor"
-            minPosition -1.75
-            maxPosition 1.75
+            minPosition -1.7
+            maxPosition 1.7
             maxVelocity 2
             sound ""
           }
@@ -39,6 +39,7 @@ PROTO SBCrane [
           }
         ]
         endPoint Solid {
+          translation 0 0.15 0  # Shift origin to be the lower face of the hook shape
           children [
             Shape {
               appearance PBRAppearance {

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -35,6 +35,7 @@ PROTO SBForklift [
                     geometry Cylinder {
                       height 0.07
                       radius 0.015
+                      subdivision 12
                     }
                   }
                 ]
@@ -247,6 +248,8 @@ PROTO SBForklift [
                     geometry Cylinder {
                       height 0.0215
                       radius 0.01
+                      subdivision 12
+                      top FALSE
                     }
                   }
                 ]
@@ -291,6 +294,9 @@ PROTO SBForklift [
                 geometry Cylinder {
                   radius 0.004
                   height 0.3
+                  subdivision 12
+                  top FALSE
+                  bottom FALSE
                 }
               }
             ]
@@ -365,6 +371,7 @@ PROTO SBForklift [
                               geometry Cylinder {
                                 height 0.016
                                 radius 0.008
+                                subdivision 16
                               }
                             }
                           ]
@@ -465,6 +472,8 @@ PROTO SBForklift [
             geometry DEF flag_pole Cylinder {
               height 0.2
               radius 0.01
+              subdivision 12
+              bottom FALSE
             }
           }
         ]
@@ -528,6 +537,8 @@ PROTO SBForklift [
                             geometry Cylinder {
                               radius 0.008
                               height 0.012
+                              subdivision 16
+                              bottom FALSE
                             }
                           }
                         ]

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -39,7 +39,9 @@ PROTO SBForklift [
                     }
                   }
                 ]
-                boundingObject USE MOTOR_HOUSING
+                boundingObject DEF MOTOR_HOUSING_GEO Box {
+                  size 0.03 0.07 0.03
+                }
                 physics Physics {
                   density 8000  # steel
                 }
@@ -94,7 +96,7 @@ PROTO SBForklift [
                 children [
                   USE MOTOR_HOUSING
                 ]
-                boundingObject USE MOTOR_HOUSING
+                boundingObject USE MOTOR_HOUSING_GEO
                 physics Physics {
                   density 8000  # steel
                 }
@@ -301,7 +303,9 @@ PROTO SBForklift [
               }
             ]
             name "Support rod 1"
-            boundingObject USE SUPPORT_ROD
+            boundingObject DEF SUPPORT_ROD_GEO Box {
+              size 0.007 0.3 0.007
+            }
             physics Physics {
               density 8000  # steel
             }
@@ -313,7 +317,7 @@ PROTO SBForklift [
               USE SUPPORT_ROD
             ]
             name "Support rod 2"
-            boundingObject USE SUPPORT_ROD
+            boundingObject USE SUPPORT_ROD_GEO
             physics Physics {
               density 8000  # steel
             }
@@ -477,7 +481,9 @@ PROTO SBForklift [
             }
           }
         ]
-        boundingObject USE flag_pole
+        boundingObject Box {
+          size 0.02 0.2 0.02
+        }
         name "flag pole"
         physics Physics {
         }

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -199,10 +199,6 @@ PROTO SBForklift [
             ]
           }
         ]
-        boundingObject USE body_geo
-        physics Physics {
-          # wood = ~700, leave at default
-        }
       }
       DEF CASTERS Transform {
         translation 0 0.0025 0.1

--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -55,6 +55,7 @@ PROTO SBForklift [
                   RotationalMotor {
                     name "left wheel"
                     maxVelocity 12.3
+                    sound ""
                   }
                   PositionSensor {
                     name "left wheel sensor"
@@ -110,6 +111,7 @@ PROTO SBForklift [
                   RotationalMotor {
                     name "right wheel"
                     maxVelocity 12.3
+                    sound ""
                   }
                   PositionSensor {
                     name "right wheel sensor"
@@ -334,6 +336,7 @@ PROTO SBForklift [
                     minPosition -0.01
                     maxPosition 0.124
                     maxVelocity 0.5
+                    sound ""
                   }
                   PositionSensor {
                     name "left gripper sensor"
@@ -411,6 +414,7 @@ PROTO SBForklift [
                     minPosition -0.01
                     maxPosition 0.124
                     maxVelocity 0.5
+                    sound ""
                   }
                   PositionSensor {
                     name "right gripper sensor"

--- a/protos/Tokens/SBToken.proto
+++ b/protos/Tokens/SBToken.proto
@@ -7,7 +7,7 @@ PROTO SBToken [
   field SFColor zoneColour 1 1 1
   field SFFloat connectorDistance 0.13
   field SFFloat connectorAngle 0.7854
-  field SFFloat connectorStrength 10
+  field SFFloat connectorStrength 30
   field SFFloat connectorShear 10
 ]
 {
@@ -37,6 +37,7 @@ PROTO SBToken [
             numberOfRotations 0
             tensileStrength IS connectorStrength
             shearStrength IS connectorShear
+            snap FALSE
             name "South Connector"
           }
           Connector {  # North connector
@@ -49,6 +50,7 @@ PROTO SBToken [
             numberOfRotations 0
             tensileStrength IS connectorStrength
             shearStrength IS connectorShear
+            snap FALSE
             name "North Connector"
           }
           Connector {  # East connector
@@ -61,6 +63,7 @@ PROTO SBToken [
             numberOfRotations 0
             tensileStrength IS connectorStrength
             shearStrength IS connectorShear
+            snap FALSE
             name "East Connector"
           }
           Connector {  # West connector
@@ -73,6 +76,7 @@ PROTO SBToken [
             numberOfRotations 0
             tensileStrength IS connectorStrength
             shearStrength IS connectorShear
+            snap FALSE
             name "West Connector"
           }
           Connector {  # Top connector
@@ -85,6 +89,7 @@ PROTO SBToken [
             numberOfRotations 0
             tensileStrength IS connectorStrength
             shearStrength IS connectorShear
+            snap FALSE
             name "Top Connector"
           }
           Connector {  # Bottom connector
@@ -97,6 +102,7 @@ PROTO SBToken [
             numberOfRotations 0
             tensileStrength IS connectorStrength
             shearStrength IS connectorShear
+            snap FALSE
             name "Bottom Connector"
           }
         ]

--- a/protos/Tokens/SBToken.proto
+++ b/protos/Tokens/SBToken.proto
@@ -7,8 +7,8 @@ PROTO SBToken [
   field SFColor zoneColour 1 1 1
   field SFFloat connectorDistance 0.13
   field SFFloat connectorAngle 0.7854
-  field SFFloat connectorStrength 30
-  field SFFloat connectorShear 10
+  field SFFloat connectorStrength 35
+  field SFFloat connectorShear 20
 ]
 {
   Solid {

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -189,15 +189,13 @@ def archive_match_recordings(archives_dir: Path) -> None:
     for path in recording_stem.parent.glob(f'{recording_stem.name}.*'):
         shutil.copy(path, recordings_dir)
 
-    try:
-        shutil.copytree(recording_stem.parent / 'textures', recordings_dir / 'textures')
-    except FileExistsError:
-        # The textures are always the same, so we don't really care if they're
-        # already there.
-        pass
-    except FileNotFoundError:
-        # If the world contains no image textures the folder is not created
-        pass
+    if (recording_stem.parent / 'textures').is_dir():
+        try:
+            shutil.copytree(recording_stem.parent / 'textures', recordings_dir / 'textures')
+        except FileExistsError:
+            # The textures are always the same, so we don't really care if they're
+            # already there.
+            pass
 
 
 def parse_args() -> argparse.Namespace:

--- a/script/run-comp-match
+++ b/script/run-comp-match
@@ -195,6 +195,9 @@ def archive_match_recordings(archives_dir: Path) -> None:
         # The textures are always the same, so we don't really care if they're
         # already there.
         pass
+    except FileNotFoundError:
+        # If the world contains no image textures the folder is not created
+        pass
 
 
 def parse_args() -> argparse.Namespace:

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -35,8 +35,7 @@ DEF ROBOT-0-forklift SBForklift {
   controllerArgs ["0", "forklift"]
 }
 DEF ROBOT-0-crane SBCrane {
-  translation -1.25 2 0
-  initPos 1.5 0 -0.5
+  translation -1.25 1.5 0
   controller "sr_controller"
   model "Robot0crane"
   flagColour 1 0 1
@@ -51,8 +50,7 @@ DEF ROBOT-1-forklift SBForklift {
   controllerArgs ["1", "forklift"]
 }
 DEF ROBOT-1-crane SBCrane {
-  translation -1.25 2 0
-  initPos -1.5 0 0.5
+  translation -1.25 1.5 0
   controller "sr_controller"
   model "Robot1crane"
   flagColour 1 1 0
@@ -309,13 +307,13 @@ DEF SHIP Transform {
 DEF CRANE_GANTRY Group {
   children [
     Solid {
-      translation 0.45 1.1 -0.8
+      translation 0.45 0.85 -0.8
       children [
         DEF pillar Shape {
           appearance PBRAppearance {
           }
           geometry Box {
-            size 0.1 2.2 0.1
+            size 0.1 1.7 0.1
           }
         }
       ]
@@ -323,7 +321,7 @@ DEF CRANE_GANTRY Group {
       name "NW pillar"
     }
     Solid {
-      translation 0.45 1.1 0.8
+      translation 0.45 0.85 0.8
       children [
         USE pillar
       ]
@@ -331,7 +329,7 @@ DEF CRANE_GANTRY Group {
       name "NE pillar"
     }
     Solid {
-      translation -2.95 1.1 0.8
+      translation -2.95 0.85 0.8
       children [
         USE pillar
       ]
@@ -339,7 +337,7 @@ DEF CRANE_GANTRY Group {
       name "SE pillar"
     }
     Solid {
-      translation -2.95 1.1 -0.8
+      translation -2.95 0.85 -0.8
       children [
         USE pillar
       ]
@@ -347,13 +345,13 @@ DEF CRANE_GANTRY Group {
       name "SW pillar"
     }
     Solid {
-      translation -1.25 2.15 -0.8
+      translation -1.25 1.65 -0.8
       children [
         DEF gantry Shape {
           appearance PBRAppearance {
           }
           geometry Box {
-            size 3.4 0.1 0.1
+            size 3.3 0.1 0.1
           }
         }
       ]
@@ -361,7 +359,7 @@ DEF CRANE_GANTRY Group {
       name "West gantry"
     }
     Solid {
-      translation -1.25 2.15 0.8
+      translation -1.25 1.65 0.8
       children [
         USE gantry
       ]

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -36,6 +36,7 @@ DEF ROBOT-0-forklift SBForklift {
 }
 DEF ROBOT-0-crane SBCrane {
   translation -1.25 1.5 0
+  initPos 1.5 0 -0.5
   controller "sr_controller"
   model "Robot0crane"
   flagColour 1 0 1
@@ -51,6 +52,7 @@ DEF ROBOT-1-forklift SBForklift {
 }
 DEF ROBOT-1-crane SBCrane {
   translation -1.25 1.5 0
+  initPos -1.5 0 0.5
   controller "sr_controller"
   model "Robot1crane"
   flagColour 1 1 0

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -305,3 +305,68 @@ DEF SHIP Transform {
     }
   ]
 }
+
+DEF CRANE_GANTRY Group {
+  children [
+    Solid {
+      translation 0.45 1.1 -0.8
+      children [
+        DEF pillar Shape {
+          appearance PBRAppearance {
+          }
+          geometry Box {
+            size 0.1 2.2 0.1
+          }
+        }
+      ]
+      boundingObject USE pillar
+      name "NW pillar"
+    }
+    Solid {
+      translation 0.45 1.1 0.8
+      children [
+        USE pillar
+      ]
+      boundingObject USE pillar
+      name "NE pillar"
+    }
+    Solid {
+      translation -2.95 1.1 0.8
+      children [
+        USE pillar
+      ]
+      boundingObject USE pillar
+      name "SE pillar"
+    }
+    Solid {
+      translation -2.95 1.1 -0.8
+      children [
+        USE pillar
+      ]
+      boundingObject USE pillar
+      name "SW pillar"
+    }
+    Solid {
+      translation -1.25 2.15 -0.8
+      children [
+        DEF gantry Shape {
+          appearance PBRAppearance {
+          }
+          geometry Box {
+            size 3.4 0.1 0.1
+          }
+        }
+      ]
+      boundingObject USE gantry
+      name "West gantry"
+    }
+    Solid {
+      translation -1.25 2.15 0.8
+      children [
+        USE gantry
+      ]
+      boundingObject USE gantry
+      name "East gantry"
+    }
+  ]
+}

--- a/worlds/Arena.wbt
+++ b/worlds/Arena.wbt
@@ -34,9 +34,9 @@ DEF ROBOT-0-forklift SBForklift {
   flagColour 1 0 1
   controllerArgs ["0", "forklift"]
 }
-DEF ROBOT-0-crane SRRobot {
-  translation -1.25 0.005 -0.8
-  rotation 0 1 0 3.14
+DEF ROBOT-0-crane SBCrane {
+  translation -1.25 2 0
+  initPos 1.5 0 -0.5
   controller "sr_controller"
   model "Robot0crane"
   flagColour 1 0 1
@@ -50,9 +50,9 @@ DEF ROBOT-1-forklift SBForklift {
   flagColour 1 1 0
   controllerArgs ["1", "forklift"]
 }
-DEF ROBOT-1-crane SRRobot {
-  translation -1.25 0.005 0.8
-  rotation 0 1 0 0
+DEF ROBOT-1-crane SBCrane {
+  translation -1.25 2 0
+  initPos -1.5 0 0.5
   controller "sr_controller"
   model "Robot1crane"
   flagColour 1 1 0


### PR DESCRIPTION
Adds a gantry-style crane with independent control of movements in the 3 axis

![Arena_36](https://user-images.githubusercontent.com/10937272/126902536-c3a6e475-1e27-4687-83a0-ad43c37d9a75.png)

Currently the attached sensors are:
- position sensors on all axis
- touch sensor on grabber
- radio reciever in the grabber head

~There is currently an issue where the grabber head can pass through the raised platforms and push tokens into the ground. This is mostly related to how the hoist cable is implemented as a driven slider joint with ball joints on either end. There is also an associated visual glitch where the the muscle node used for the rope doesn't show up.~

fixes #6 