### PR TITLE
Run remote dev match

### DIFF
--- a/controllers/competition_supervisor/competition_supervisor.py
+++ b/controllers/competition_supervisor/competition_supervisor.py
@@ -81,29 +81,9 @@ def propagate_exit_code(supervisor: Supervisor) -> Iterator[None]:
 
 
 def quit_if_development_mode() -> None:
-    if controller_utils.get_robot_mode() == 'remote-dev':
-        print("Entering remote development mode")
-        run_dev_remote_mode()
-        exit()
-    if controller_utils.get_robot_mode() != 'comp':
+    if controller_utils.get_robot_mode() == 'dev':
         print("Development mode, exiting competition supervisor")
         exit()
-
-
-def run_dev_remote_mode() -> None:
-    controller_utils.tee_streams(
-        controller_utils.get_competition_supervisor_log_filepath(),
-    )
-
-    supervisor = Supervisor()
-
-    with propagate_exit_code(supervisor):
-        supervisor.simulationSetMode(Supervisor.SIMULATION_MODE_PAUSE)
-
-        recording_stem = controller_utils.get_recording_stem()
-
-        with record_animation(supervisor, recording_stem.with_suffix('.html')):
-            run_match(supervisor, do_inform_start=False)
 
 
 def check_required_libraries(path: Path) -> None:
@@ -254,8 +234,12 @@ def main() -> None:
         recording_stem = controller_utils.get_recording_stem()
 
         with record_animation(supervisor, recording_stem.with_suffix('.html')):
-            with record_video(supervisor, recording_stem.with_suffix('.mp4')):
+            # Don't record video in remote dev
+            if controller_utils.get_robot_mode() == 'remote-dev':
                 run_match(supervisor)
+            else:
+                with record_video(supervisor, recording_stem.with_suffix('.mp4')):
+                    run_match(supervisor)
 
 
 if __name__ == '__main__':

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -120,7 +120,7 @@ class Robot:
             self._timestep * random.randint(8, 20),
         )
 
-        if self.mode in {'comp', 'remote-dev'}:
+        if self.mode in ['comp', 'remote-dev']:
             # Interact with the supervisor "robot" to wait for the start of the match.
             self.webot.setCustomData('ready')
             while (

--- a/modules/sr/robot/robot.py
+++ b/modules/sr/robot/robot.py
@@ -120,7 +120,7 @@ class Robot:
             self._timestep * random.randint(8, 20),
         )
 
-        if self.mode == 'comp':
+        if self.mode in {'comp', 'remote-dev'}:
             # Interact with the supervisor "robot" to wait for the start of the match.
             self.webot.setCustomData('ready')
             while (

--- a/script/run-remote-dev-match
+++ b/script/run-remote-dev-match
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+A script to run a remote dev match.
+"""
+
+import os
+import sys
+import shutil
+import argparse
+import tempfile
+import contextlib
+import subprocess
+from typing import Iterator
+from pathlib import Path
+from datetime import datetime
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.insert(1, str(REPO_ROOT / 'modules'))
+
+import controller_utils  # isort:skip
+from shared_utils import RobotType  # isort:skip
+
+
+def get_zone_path(zone_id: int) -> Path:
+    # All robot types have a common path so we just use the first enum option
+    robot_file: Path = controller_utils.get_zone_robot_file_path(zone_id, RobotType.FORKLIFT)
+    return robot_file.parent
+
+
+@contextlib.contextmanager
+def temporary_arena_root(suffix: str) -> Iterator[None]:
+    original_arena_root = controller_utils.ARENA_ROOT
+    with tempfile.TemporaryDirectory(suffix=suffix) as tmpdir_name:
+        print(f"Using {tmpdir_name!r} as the arena")  # noqa:T001
+        os.environ['ARENA_ROOT'] = tmpdir_name
+        controller_utils.ARENA_ROOT = Path(tmpdir_name)
+        try:
+            yield
+        finally:
+            os.environ['ARENA_ROOT'] = str(original_arena_root)
+            controller_utils.ARENA_ROOT = original_arena_root
+
+
+def prepare_match(source_dir: Path) -> None:
+    controller_utils.get_mode_file().write_text('remote-dev\n')
+
+    # Copy the zone files into the right place
+    for zone_id in [0, 1]:
+        zone_path = get_zone_path(zone_id)
+        zone_source = source_dir / f"zone-{zone_id}"
+        if zone_source.is_dir():
+            shutil.copytree(source_dir / f"zone-{zone_id}", zone_path)
+
+
+def print_error(message: str, *, strong: bool = False) -> None:
+    BOLD = '\033[1m' if strong else ''
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    return print(f"{BOLD}{FAIL}{message}{ENDC}")  # noqa:T001
+
+
+def print_fatal(message: str) -> None:
+    return print_error(message, strong=True)
+
+
+def run_match() -> str:
+    try:
+        return subprocess.check_output([
+            'webots',
+            '--batch',
+            '--stdout',
+            '--stderr',
+            '--minimize',
+            '--mode=realtime',
+            str(REPO_ROOT / 'worlds' / 'Arena.wbt'),
+        ], stderr=subprocess.STDOUT, universal_newlines=True)
+    except FileNotFoundError:
+        print_fatal(
+            "Could not find webots. Check that you have it installed and on your PATH",
+        )
+        exit(1)
+    except subprocess.CalledProcessError as e:
+        try:
+            log_text = controller_utils.get_competition_supervisor_log_filepath().read_text()
+        except FileNotFoundError:
+            print_fatal(
+                f"Simulation errored (exit code {e.returncode}). "
+                "No supervisor logs were found - Webots may have crashed.",
+            )
+        else:
+            # There are potentially a large number of lines in the logs and any
+            # errors are likely to be at the end of the logs. Additionally, the
+            # user's focus is initially likely to be at the end of the output.
+            # To ensure that failures are clear we therefore put the message that
+            # there was a failure last in the output (and in bold).
+            print_error(log_text)
+            print_fatal(
+                f"Simulation errored (exit code {e.returncode}). "
+                f"Competition supervisor logs are above.",
+            )
+
+        exit(1)
+
+
+def archive_match_outputs(archives_dir: Path, match_logs: str) -> None:
+    """
+    Copy the recordings and logs to the output directory.
+    """
+
+    output_dir = archives_dir / "output" / datetime.now().isoformat().replace(':', '_')
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    (output_dir / "logs.txt").write_text(match_logs)
+
+    recording_dir = controller_utils.get_recording_stem().parent
+
+    # We don't want to rely on the recordings going into a directory which only
+    # contains recording data, so instead we copy explicitly the things which we
+    # know will have been output.
+
+    for path in recording_dir.glob('*'):
+        shutil.copy(path, output_dir)
+
+    textures_dir = recording_dir / 'textures'
+
+    # If we don't have textures, the directory won't exist.
+    if textures_dir.is_dir():
+        shutil.copytree(textures_dir, output_dir / 'textures')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'source_dir',
+        help=(
+            "The directory containing the teams' robot code. This directory "
+            "will also be used as the root for storing the resulting logs and "
+            "recordings."
+        ),
+        type=Path,
+    )
+    parser.add_argument(
+        '--duration',
+        help="The duration of the match (in seconds).",
+        type=int,
+        default=controller_utils.GAME_DURATION_SECONDS,
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace) -> None:
+    with temporary_arena_root(datetime.now().isoformat().replace(':', '_')):
+        prepare_match(args.source_dir)
+
+        match_logs = run_match()
+
+        archive_match_outputs(args.source_dir, match_logs)
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/script/run-remote-dev-match
+++ b/script/run-remote-dev-match
@@ -108,7 +108,7 @@ def archive_match_outputs(archives_dir: Path, match_logs: str) -> None:
     Copy the recordings and logs to the output directory.
     """
 
-    output_dir = archives_dir / "output" / datetime.now().isoformat().replace(':', '_')
+    output_dir = archives_dir / "output" / datetime.now().strftime('%c')
     output_dir.mkdir(exist_ok=True, parents=True)
 
     (output_dir / "logs.txt").write_text(match_logs)

--- a/script/run-remote-dev-match
+++ b/script/run-remote-dev-match
@@ -12,7 +12,6 @@ import contextlib
 import subprocess
 from typing import Iterator
 from pathlib import Path
-from datetime import datetime
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -108,7 +107,7 @@ def archive_match_outputs(archives_dir: Path, match_logs: str) -> None:
     Copy the recordings and logs to the output directory.
     """
 
-    output_dir = archives_dir / "output" / datetime.now().strftime('%c')
+    output_dir = archives_dir / "output" / controller_utils.get_filename_safe_identifier()
     output_dir.mkdir(exist_ok=True, parents=True)
 
     (output_dir / "logs.txt").write_text(match_logs)
@@ -150,7 +149,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
-    with temporary_arena_root(datetime.now().isoformat().replace(':', '_')):
+    with temporary_arena_root(controller_utils.get_filename_safe_identifier()):
         prepare_match(args.source_dir)
 
         match_logs = run_match()

--- a/script/run-remote-dev-match
+++ b/script/run-remote-dev-match
@@ -41,15 +41,15 @@ def temporary_arena_root(suffix: str) -> Iterator[None]:
             controller_utils.ARENA_ROOT = original_arena_root
 
 
-def prepare_match(source_dir: Path) -> None:
+def prepare_match(code_dir: Path) -> None:
     controller_utils.get_mode_file().write_text('remote-dev\n')
 
     # Copy the zone files into the right place
     for zone_id in [0, 1]:
         zone_path = get_zone_path(zone_id)
-        zone_source = source_dir / f"zone-{zone_id}"
+        zone_source = code_dir / f"zone-{zone_id}"
         if zone_source.is_dir():
-            shutil.copytree(source_dir / f"zone-{zone_id}", zone_path)
+            shutil.copytree(code_dir / f"zone-{zone_id}", zone_path)
 
 
 def print_error(message: str, *, strong: bool = False) -> None:
@@ -102,12 +102,12 @@ def run_match() -> str:
         exit(1)
 
 
-def archive_match_outputs(archives_dir: Path, match_logs: str) -> None:
+def archive_match_outputs(code_dir: Path, match_logs: str) -> None:
     """
     Copy the recordings and logs to the output directory.
     """
 
-    output_dir = archives_dir / "output" / controller_utils.get_filename_safe_identifier()
+    output_dir = code_dir / "output" / controller_utils.get_filename_safe_identifier()
     output_dir.mkdir(exist_ok=True, parents=True)
 
     (output_dir / "logs.txt").write_text(match_logs)
@@ -131,7 +131,7 @@ def archive_match_outputs(archives_dir: Path, match_logs: str) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        'source_dir',
+        'code_dir',
         help=(
             "The directory containing the teams' robot code. This directory "
             "will also be used as the root for storing the resulting logs and "
@@ -150,11 +150,11 @@ def parse_args() -> argparse.Namespace:
 
 def main(args: argparse.Namespace) -> None:
     with temporary_arena_root(controller_utils.get_filename_safe_identifier()):
-        prepare_match(args.source_dir)
+        prepare_match(args.code_dir)
 
         match_logs = run_match()
 
-        archive_match_outputs(args.source_dir, match_logs)
+        archive_match_outputs(args.code_dir, match_logs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #58 

This adds an additional runner script which runs against a directory of a team's code, and outputs the recordings and logs into a sibling `output` directory, grouped by run date/time.

```
.
├── output
│   └── Sat Aug  7 18:33:49 2021
│       ├── 2021-08-07T18_31_56.html
│       ├── 2021-08-07T18_31_56.json
│       ├── 2021-08-07T18_31_56.x3d
│       └── logs.txt
└── zone-0
    ├── crane.py
    └── forklift.py
```

Support for this structure in https://github.com/RealOrangeOne/simulator-runner/ is coming soon, but the fundamentals are there.