### PR TITLE
Set the maximum torque on the forklift motors lower

### DIFF
--- a/protos/Forklift/SBForklift.proto
+++ b/protos/Forklift/SBForklift.proto
@@ -55,6 +55,7 @@ PROTO SBForklift [
                   RotationalMotor {
                     name "left wheel"
                     maxVelocity 12.3
+                    maxTorque 0.1
                     sound ""
                   }
                   PositionSensor {
@@ -111,6 +112,7 @@ PROTO SBForklift [
                   RotationalMotor {
                     name "right wheel"
                     maxVelocity 12.3
+                    maxTorque 0.1
                     sound ""
                   }
                   PositionSensor {


### PR DESCRIPTION
The rated maximum torque on the RS drill motors we usually use at Smallpeice is 1 kgf-cm. After conversion to a unit which isn't brain-dead that's about 0.1Nm.

This makes the robots accelerate to maximum speed not instantly.