### PR TITLE
jitter should always be a float

### DIFF
--- a/modules/sbot/randomizer.py
+++ b/modules/sbot/randomizer.py
@@ -23,7 +23,7 @@ def add_jitter(
 ) -> float:
     random_range = actual_value * (random_range_percent / float(100))
     new_value = actual_value + random.uniform(-random_range, random_range)
-    return max(min_possible, min(new_value, max_possible))
+    return float(max(min_possible, min(new_value, max_possible)))
 
 
 def add_independent_jitter(
@@ -38,6 +38,6 @@ def add_independent_jitter(
     new_value = random.gauss(actual_value, std_dev)
     if can_wrap:
         new_value_normalised = new_value - min_possible
-        return (new_value_normalised % value_range) + min_possible
+        return float((new_value_normalised % value_range) + min_possible)
     else:
-        return max(min_possible, min(new_value, max_possible))
+        return float(max(min_possible, min(new_value, max_possible)))

--- a/modules/sbot/randomizer.py
+++ b/modules/sbot/randomizer.py
@@ -20,10 +20,10 @@ def add_jitter(
     min_possible: T,
     max_possible: T,
     random_range_percent: float = DEFAULT_RANDOM_RANGE_PERCENT,
-) -> T:
+) -> float:
     random_range = actual_value * (random_range_percent / float(100))
     new_value = actual_value + random.uniform(-random_range, random_range)
-    return type(actual_value)(max(min_possible, min(new_value, max_possible)))
+    return max(min_possible, min(new_value, max_possible))
 
 
 def add_independent_jitter(
@@ -32,12 +32,12 @@ def add_independent_jitter(
     max_possible: T,
     std_dev_percent: float = DEFAULT_RANDOM_INDEPENDENT_RANGE_PERCENT,  # % of full scale value
     can_wrap: bool = False,
-) -> T:
+) -> float:
     value_range = max_possible - min_possible
     std_dev = value_range * (std_dev_percent / float(100))
     new_value = random.gauss(actual_value, std_dev)
     if can_wrap:
         new_value_normalised = new_value - min_possible
-        return type(actual_value)((new_value_normalised % value_range) + min_possible)
+        return (new_value_normalised % value_range) + min_possible
     else:
-        return type(actual_value)(max(min_possible, min(new_value, max_possible)))
+        return max(min_possible, min(new_value, max_possible))


### PR DESCRIPTION
Fixes #72 

When rounding `1`, it would become 0 as the decimals get truncated.

There are occasions where the jitter output is shown to the user, but I don't think that will cause us issues.

