### PR TITLE
Handle token scorer setting every token to ARENA before closing

### DIFF
--- a/controllers/token_scorer/token_scorer.py
+++ b/controllers/token_scorer/token_scorer.py
@@ -263,6 +263,14 @@ class TokenScorer:
     def process_token_locations(self) -> None:
         observed_tokens: List[TargetInfo] = []
 
+        if sum(
+            receiver.getQueueLength()
+            for receiver in self._scoring_receivers.keys()
+        ) == 0:
+            # beacons are always visible from the scorer
+            # so if nothing is received then the token_controller has ended
+            return
+
         for receiver, receiver_location in self._scoring_receivers.items():
             while receiver.getQueueLength():
                 try:


### PR DESCRIPTION
This is caused by a race condition between the `token_controller` and `token_scorer`. This causes no tokens to be detected on the first and last token scan. 

Since the beacons are always visible and driven by the token_controller we can detect this race condition by detecting when the beacons have not been picked up.

Obviously this doesn't fix matches that have already run but will stop it occuring in future matches.